### PR TITLE
Add annotation to all playbooks

### DIFF
--- a/plugins/modules/aci_aaa_user.py
+++ b/plugins/modules/aci_aaa_user.py
@@ -20,6 +20,11 @@ description:
 requirements:
 - python-dateutil
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   aaa_password:
     description:
     - The password of the locally-authenticated user.
@@ -268,6 +273,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         aaa_password=dict(type='str', no_log=True),
         aaa_password_lifetime=dict(type='int'),
         aaa_password_update_required=dict(type='bool'),
@@ -301,6 +307,7 @@ def main():
         module.fail_json(msg='dateutil required for this module')
 
     aaa_password = module.params.get('aaa_password')
+    annotation = module.params.get('annotation')
     aaa_password_lifetime = module.params.get('aaa_password_lifetime')
     aaa_password_update_required = aci.boolean(module.params.get('aaa_password_update_required'))
     aaa_user = module.params.get('aaa_user')

--- a/plugins/modules/aci_aaa_user_certificate.py
+++ b/plugins/modules/aci_aaa_user_certificate.py
@@ -18,6 +18,11 @@ short_description: Manage AAA user certificates (aaa:UserCert)
 description:
 - Manage AAA user certificates on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   aaa_user:
     description:
     - The name of the user to add a certificate to.
@@ -232,6 +237,7 @@ ACI_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         aaa_user=dict(type='str', required=True),
         aaa_user_type=dict(type='str', default='user', choices=['appuser', 'user']),
         certificate=dict(type='str', aliases=['cert_data', 'certificate_data']),
@@ -250,6 +256,7 @@ def main():
     )
 
     aaa_user = module.params.get('aaa_user')
+    annotation = module.params.get('annotation')
     aaa_user_type = module.params.get('aaa_user_type')
     certificate = module.params.get('certificate')
     certificate_name = module.params.get('certificate_name')

--- a/plugins/modules/aci_access_port_block_to_access_port.py
+++ b/plugins/modules/aci_access_port_block_to_access_port.py
@@ -18,6 +18,11 @@ short_description: Manage port blocks of Fabric interface policy leaf profile in
 description:
 - Manage port blocks of Fabric interface policy leaf profile interface selectors on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
@@ -264,6 +269,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         leaf_interface_profile=dict(type='str', aliases=['leaf_interface_profile_name']),  # Not required for querying all objects
         access_port_selector=dict(type='str', aliases=['name', 'access_port_selector_name']),  # Not required for querying all objects
         leaf_port_blk=dict(type='str', aliases=['leaf_port_blk_name']),  # Not required for querying all objects
@@ -285,6 +291,7 @@ def main():
     )
 
     leaf_interface_profile = module.params.get('leaf_interface_profile')
+    annotation = module.params.get('annotation')
     access_port_selector = module.params.get('access_port_selector')
     leaf_port_blk = module.params.get('leaf_port_blk')
     leaf_port_blk_description = module.params.get('leaf_port_blk_description')

--- a/plugins/modules/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/plugins/modules/aci_access_port_to_interface_policy_leaf_profile.py
@@ -18,6 +18,11 @@ short_description: Manage Fabric interface policy leaf profile interface selecto
 description:
 - Manage Fabric interface policy leaf profile interface selectors on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
@@ -290,6 +295,7 @@ INTERFACE_TYPE_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         leaf_interface_profile=dict(type='str', aliases=['leaf_interface_profile_name']),  # Not required for querying all objects
         access_port_selector=dict(type='str', aliases=['name', 'access_port_selector_name']),  # Not required for querying all objects
         description=dict(type='str'),
@@ -314,6 +320,7 @@ def main():
     )
 
     leaf_interface_profile = module.params.get('leaf_interface_profile')
+    annotation = module.params.get('annotation')
     access_port_selector = module.params.get('access_port_selector')
     description = module.params.get('description')
     leaf_port_blk = module.params.get('leaf_port_blk')

--- a/plugins/modules/aci_access_sub_port_block_to_access_port.py
+++ b/plugins/modules/aci_access_sub_port_block_to_access_port.py
@@ -24,6 +24,11 @@ seealso:
 author:
 - Simon Metzger (@smnmtzgr)
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
@@ -282,6 +287,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         leaf_interface_profile=dict(type='str', aliases=['leaf_interface_profile_name']),  # Not required for querying all objects
         access_port_selector=dict(type='str', aliases=['name', 'access_port_selector_name']),  # Not required for querying all objects
         leaf_port_blk=dict(type='str', aliases=['leaf_port_blk_name']),  # Not required for querying all objects
@@ -305,6 +311,7 @@ def main():
     )
 
     leaf_interface_profile = module.params.get('leaf_interface_profile')
+    annotation = module.params.get('annotation')
     access_port_selector = module.params.get('access_port_selector')
     leaf_port_blk = module.params.get('leaf_port_blk')
     leaf_port_blk_description = module.params.get('leaf_port_blk_description')

--- a/plugins/modules/aci_aep.py
+++ b/plugins/modules/aci_aep.py
@@ -18,6 +18,11 @@ description:
 - Connect to external virtual and physical domains by using
   attachable Access Entity Profiles (AEP) on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   aep:
     description:
     - The name of the Attachable Access Entity Profile.
@@ -211,6 +216,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         aep=dict(type='str', aliases=['name', 'aep_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         infra_vlan=dict(type='bool', aliases=['infrastructure_vlan']),
@@ -228,6 +234,7 @@ def main():
     )
 
     aep = module.params.get('aep')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     infra_vlan = module.params.get('infra_vlan')
     state = module.params.get('state')

--- a/plugins/modules/aci_aep_to_domain.py
+++ b/plugins/modules/aci_aep_to_domain.py
@@ -18,6 +18,11 @@ short_description: Bind AEPs to Physical or Virtual Domains (infra:RsDomP)
 description:
 - Bind AEPs to Physical or Virtual Domains on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   aep:
     description:
     - The name of the Attachable Access Entity Profile.
@@ -231,6 +236,7 @@ VM_PROVIDER_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         aep=dict(type='str', aliases=['aep_name']),  # Not required for querying all objects
         domain=dict(type='str', aliases=['domain_name', 'domain_profile']),  # Not required for querying all objects
         domain_type=dict(type='str', choices=['fc', 'l2dom', 'l3dom', 'phys', 'vmm'], aliases=['type']),  # Not required for querying all objects
@@ -252,6 +258,7 @@ def main():
     )
 
     aep = module.params.get('aep')
+    annotation = module.params.get('annotation')
     domain = module.params.get('domain')
     domain_type = module.params.get('domain_type')
     vm_provider = module.params.get('vm_provider')

--- a/plugins/modules/aci_ap.py
+++ b/plugins/modules/aci_ap.py
@@ -17,6 +17,11 @@ short_description: Manage top level Application Profile (AP) objects (fv:Ap)
 description:
 - Manage top level Application Profile (AP) objects on Cisco ACI fabrics
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - The name of an existing tenant.
@@ -216,6 +221,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         ap=dict(type='str', aliases=['app_profile', 'app_profile_name', 'name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -233,6 +239,7 @@ def main():
     )
 
     ap = module.params.get('ap')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     tenant = module.params.get('tenant')

--- a/plugins/modules/aci_bd.py
+++ b/plugins/modules/aci_bd.py
@@ -17,6 +17,11 @@ short_description: Manage Bridge Domains (BD) objects (fv:BD)
 description:
 - Manages Bridge Domains (BD) on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   arp_flooding:
     description:
     - Determines if the Bridge Domain should flood ARP traffic.
@@ -337,6 +342,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         arp_flooding=dict(type='bool'),
         bd=dict(type='str', aliases=['bd_name', 'name']),  # Not required for querying all objects
         bd_type=dict(type='str', choices=['ethernet', 'fc']),
@@ -373,6 +379,7 @@ def main():
     aci = ACIModule(module)
 
     arp_flooding = aci.boolean(module.params.get('arp_flooding'))
+    annotation = module.params.get('annotation')
     bd = module.params.get('bd')
     bd_type = module.params.get('bd_type')
     if bd_type == 'ethernet':

--- a/plugins/modules/aci_bd_subnet.py
+++ b/plugins/modules/aci_bd_subnet.py
@@ -17,6 +17,11 @@ short_description: Manage Subnets (fv:Subnet)
 description:
 - Manage Subnets on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   bd:
     description:
     - The name of the Bridge Domain.
@@ -352,6 +357,7 @@ SUBNET_CONTROL_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         bd=dict(type='str', aliases=['bd_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         enable_vip=dict(type='bool'),
@@ -382,6 +388,7 @@ def main():
     aci = ACIModule(module)
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     enable_vip = aci.boolean(module.params.get('enable_vip'))
     tenant = module.params.get('tenant')
     bd = module.params.get('bd')

--- a/plugins/modules/aci_bd_to_l3out.py
+++ b/plugins/modules/aci_bd_to_l3out.py
@@ -17,6 +17,11 @@ short_description: Bind Bridge Domain to L3 Out (fv:RsBDToOut)
 description:
 - Bind Bridge Domain to L3 Out on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   bd:
     description:
     - The name of the Bridge Domain.
@@ -176,6 +181,7 @@ SUBNET_CONTROL_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         bd=dict(type='str', aliases=['bd_name', 'bridge_domain']),  # Not required for querying all objects
         l3out=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
@@ -193,6 +199,7 @@ def main():
     )
 
     bd = module.params.get('bd')
+    annotation = module.params.get('annotation')
     l3out = module.params.get('l3out')
     state = module.params.get('state')
     tenant = module.params.get('tenant')

--- a/plugins/modules/aci_config_rollback.py
+++ b/plugins/modules/aci_config_rollback.py
@@ -18,6 +18,11 @@ description:
 - Provides rollback and rollback preview functionality for Cisco ACI fabrics.
 - Config Rollbacks are done using snapshots C(aci_snapshot) with the configImportP class.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   compare_export_policy:
     description:
     - The export policy that the C(compare_snapshot) is associated to.
@@ -204,6 +209,7 @@ except ImportError:
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         compare_export_policy=dict(type='str'),
         compare_snapshot=dict(type='str'),
         description=dict(type='str', aliases=['descr']),
@@ -228,6 +234,7 @@ def main():
     aci = ACIModule(module)
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     export_policy = module.params.get('export_policy')
     fail_on_decrypt = aci.boolean(module.params.get('fail_on_decrypt'))
     import_mode = module.params.get('import_mode')

--- a/plugins/modules/aci_config_snapshot.py
+++ b/plugins/modules/aci_config_snapshot.py
@@ -19,6 +19,11 @@ description:
 - Creating new Snapshots is done using the configExportP class.
 - Removing Snapshots is done using the configSnapshot class.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   description:
     description:
     - The description for the Config Export Policy.
@@ -227,6 +232,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         export_policy=dict(type='str', aliases=['name']),  # Not required for querying all objects
         format=dict(type='str', choices=['json', 'xml']),
@@ -248,6 +254,7 @@ def main():
     aci = ACIModule(module)
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     export_policy = module.params.get('export_policy')
     file_format = module.params.get('format')
     include_secure = aci.boolean(module.params.get('include_secure'))

--- a/plugins/modules/aci_contract.py
+++ b/plugins/modules/aci_contract.py
@@ -17,6 +17,11 @@ short_description: Manage contract resources (vz:BrCP)
 description:
 - Manage Contract resources on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   contract:
     description:
     - The name of the contract.
@@ -238,6 +243,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         contract=dict(type='str', aliases=['contract_name', 'name']),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -261,6 +267,7 @@ def main():
     )
 
     contract = module.params.get('contract')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     scope = module.params.get('scope')
     priority = module.params.get('priority')

--- a/plugins/modules/aci_contract_subject.py
+++ b/plugins/modules/aci_contract_subject.py
@@ -17,6 +17,11 @@ short_description: Manage initial Contract Subjects (vz:Subj)
 description:
 - Manage initial Contract Subjects on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - The name of the tenant.
@@ -264,6 +269,7 @@ MATCH_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         contract=dict(type='str', aliases=['contract_name']),  # Not required for querying all objects
         subject=dict(type='str', aliases=['contract_subject', 'name', 'subject_name']),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
@@ -291,6 +297,7 @@ def main():
     aci = ACIModule(module)
 
     subject = module.params.get('subject')
+    annotation = module.params.get('annotation')
     priority = module.params.get('priority')
     reverse_filter = aci.boolean(module.params.get('reverse_filter'))
     contract = module.params.get('contract')

--- a/plugins/modules/aci_contract_subject_to_filter.py
+++ b/plugins/modules/aci_contract_subject_to_filter.py
@@ -17,6 +17,11 @@ short_description: Bind Contract Subjects to Filters (vz:RsSubjFiltAtt)
 description:
 - Bind Contract Subjects to Filters on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   contract:
     description:
     - The name of the contract.
@@ -233,6 +238,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         contract=dict(type='str', aliases=['contract_name']),  # Not required for querying all objects
         filter=dict(type='str', aliases=['filter_name']),  # Not required for querying all objects
         subject=dict(type='str', aliases=['contract_subject', 'subject_name']),  # Not required for querying all objects
@@ -251,6 +257,7 @@ def main():
     )
 
     contract = module.params.get('contract')
+    annotation = module.params.get('annotation')
     filter_name = module.params.get('filter')
     log = module.params.get('log')
     subject = module.params.get('subject')

--- a/plugins/modules/aci_domain.py
+++ b/plugins/modules/aci_domain.py
@@ -17,6 +17,11 @@ short_description: Manage physical, virtual, bridged, routed or FC domain profil
 description:
 - Manage physical, virtual, bridged, routed or FC domain profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   domain:
     description:
     - Name of the physical, virtual, bridged routed or FC domain profile.
@@ -280,6 +285,7 @@ VSWITCH_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         domain_type=dict(type='str', required=True, choices=['fc', 'l2dom', 'l3dom', 'phys', 'vmm'], aliases=['type']),
         domain=dict(type='str', aliases=['domain_name', 'domain_profile', 'name']),  # Not required for querying all objects
         dscp=dict(type='str',
@@ -305,6 +311,7 @@ def main():
     )
 
     dscp = module.params.get('dscp')
+    annotation = module.params.get('annotation')
     domain = module.params.get('domain')
     domain_type = module.params.get('domain_type')
     encap_mode = module.params.get('encap_mode')

--- a/plugins/modules/aci_domain_to_encap_pool.py
+++ b/plugins/modules/aci_domain_to_encap_pool.py
@@ -21,6 +21,11 @@ notes:
 - The C(domain) and C(encap_pool) parameters should exist before using this module.
   The M(aci_domain) and M(aci_encap_pool) can be used for these.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   domain:
     description:
     - Name of the domain being associated with the Encap Pool.
@@ -266,6 +271,7 @@ POOL_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         domain_type=dict(type='str', required=True, choices=['fc', 'l2dom', 'l3dom', 'phys', 'vmm']),
         pool_type=dict(type='str', required=True, choices=['vlan', 'vsan', 'vxlan']),
         domain=dict(type='str', aliases=['domain_name', 'domain_profile']),  # Not required for querying all objects
@@ -286,6 +292,7 @@ def main():
     )
 
     domain = module.params.get('domain')
+    annotation = module.params.get('annotation')
     domain_type = module.params.get('domain_type')
     pool = module.params.get('pool')
     pool_allocation_mode = module.params.get('pool_allocation_mode')

--- a/plugins/modules/aci_domain_to_vlan_pool.py
+++ b/plugins/modules/aci_domain_to_vlan_pool.py
@@ -18,6 +18,11 @@ short_description: Bind Domain to VLAN Pools (infra:RsVlanNs)
 description:
 - Bind Domain to VLAN Pools on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   domain:
     description:
     - Name of the domain being associated with the VLAN Pool.
@@ -267,6 +272,7 @@ VM_PROVIDER_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         domain_type=dict(type='str', required=True, choices=['fc', 'l2dom', 'l3dom', 'phys', 'vmm']),
         domain=dict(type='str', aliases=['domain_name', 'domain_profile']),  # Not required for querying all objects
         pool=dict(type='str', aliases=['pool_name', 'vlan_pool']),  # Not required for querying all objects
@@ -286,6 +292,7 @@ def main():
     )
 
     domain = module.params.get('domain')
+    annotation = module.params.get('annotation')
     domain_type = module.params.get('domain_type')
     pool = module.params.get('pool')
     pool_allocation_mode = module.params.get('pool_allocation_mode')

--- a/plugins/modules/aci_encap_pool.py
+++ b/plugins/modules/aci_encap_pool.py
@@ -17,6 +17,11 @@ short_description: Manage encap pools (fvns:VlanInstP, fvns:VxlanInstP, fvns:Vsa
 description:
 - Manage vlan, vxlan, and vsan pools on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   description:
     description:
     - Description for the C(pool).
@@ -237,6 +242,7 @@ ACI_POOL_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         pool_type=dict(type='str', required=True, aliases=['type'], choices=['vlan', 'vsan', 'vxlan']),
         description=dict(type='str', aliases=['descr']),
         pool=dict(type='str', aliases=['name', 'pool_name']),  # Not required for querying all objects
@@ -255,6 +261,7 @@ def main():
     )
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     pool = module.params.get('pool')
     pool_type = module.params.get('pool_type')
     pool_allocation_mode = module.params.get('pool_allocation_mode')

--- a/plugins/modules/aci_encap_pool_range.py
+++ b/plugins/modules/aci_encap_pool_range.py
@@ -17,6 +17,11 @@ short_description: Manage encap ranges assigned to pools (fvns:EncapBlk, fvns:Vs
 description:
 - Manage vlan, vxlan, and vsan ranges that are assigned to pools on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   allocation_mode:
     description:
     - The method used for allocating encaps to resources.
@@ -306,6 +311,7 @@ ACI_POOL_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         pool_type=dict(type='str', required=True, aliases=['type'], choices=['vlan', 'vxlan', 'vsan']),
         allocation_mode=dict(type='str', aliases=['mode'], choices=['dynamic', 'inherit', 'static']),
         description=dict(type='str', aliases=['descr']),
@@ -328,6 +334,7 @@ def main():
     )
 
     allocation_mode = module.params.get('allocation_mode')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     pool = module.params.get('pool')
     pool_allocation_mode = module.params.get('pool_allocation_mode')

--- a/plugins/modules/aci_epg.py
+++ b/plugins/modules/aci_epg.py
@@ -17,6 +17,11 @@ short_description: Manage End Point Groups (EPG) objects (fv:AEPg)
 description:
 - Manage End Point Groups (EPG) on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - Name of an existing tenant.
@@ -297,6 +302,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         epg=dict(type='str', aliases=['epg_name', 'name']),  # Not required for querying all objects
         bd=dict(type='str', aliases=['bd_name', 'bridge_domain']),
         ap=dict(type='str', aliases=['app_profile', 'app_profile_name']),  # Not required for querying all objects
@@ -322,6 +328,7 @@ def main():
     aci = ACIModule(module)
 
     epg = module.params.get('epg')
+    annotation = module.params.get('annotation')
     bd = module.params.get('bd')
     description = module.params.get('description')
     priority = module.params.get('priority')

--- a/plugins/modules/aci_epg_monitoring_policy.py
+++ b/plugins/modules/aci_epg_monitoring_policy.py
@@ -17,6 +17,11 @@ short_description: Manage monitoring policies (mon:EPGPol)
 description:
 - Manage monitoring policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   monitoring_policy:
     description:
     - The name of the monitoring policy.
@@ -184,6 +189,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         monitoring_policy=dict(type='str', aliases=['name']),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -201,6 +207,7 @@ def main():
     )
 
     monitoring_policy = module.params.get('monitoring_policy')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     tenant = module.params.get('tenant')

--- a/plugins/modules/aci_epg_to_contract.py
+++ b/plugins/modules/aci_epg_to_contract.py
@@ -20,6 +20,11 @@ notes:
 - The C(tenant), C(app_profile), C(EPG), and C(Contract) used must exist before using this module in your playbook.
   The M(aci_tenant), M(aci_ap), M(aci_epg), and M(aci_contract) modules can be used for this.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   ap:
     description:
     - Name of an existing application network profile, that will contain the EPGs.
@@ -261,6 +266,7 @@ PROVIDER_MATCH_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         contract_type=dict(type='str', required=True, choices=['consumer', 'provider']),
         ap=dict(type='str', aliases=['app_profile', 'app_profile_name']),  # Not required for querying all objects
         epg=dict(type='str', aliases=['epg_name']),  # Not required for querying all objects
@@ -281,6 +287,7 @@ def main():
     )
 
     ap = module.params.get('ap')
+    annotation = module.params.get('annotation')
     contract = module.params.get('contract')
     contract_type = module.params.get('contract_type')
     epg = module.params.get('epg')

--- a/plugins/modules/aci_epg_to_domain.py
+++ b/plugins/modules/aci_epg_to_domain.py
@@ -17,6 +17,11 @@ short_description: Bind EPGs to Domains (fv:RsDomAtt)
 description:
 - Bind EPGs to Physical and Virtual Domains on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   allow_useg:
     description:
     - Allows micro-segmentation.
@@ -297,6 +302,7 @@ VM_PROVIDER_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         allow_useg=dict(type='str', choices=['encap', 'useg']),
         ap=dict(type='str', aliases=['app_profile', 'app_profile_name']),  # Not required for querying all objects
         deploy_immediacy=dict(type='str', choices=['immediate', 'lazy']),
@@ -327,6 +333,7 @@ def main():
     aci = ACIModule(module)
 
     allow_useg = module.params.get('allow_useg')
+    annotation = module.params.get('annotation')
     ap = module.params.get('ap')
     deploy_immediacy = module.params.get('deploy_immediacy')
     domain = module.params.get('domain')

--- a/plugins/modules/aci_fabric_node.py
+++ b/plugins/modules/aci_fabric_node.py
@@ -18,6 +18,11 @@ short_description: Manage Fabric Node Members (fabric:NodeIdentP)
 description:
 - Manage Fabric Node Members on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   pod_id:
     description:
     - The pod id of the new Fabric Node Member.
@@ -216,6 +221,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         node_id=dict(type='int'),  # Not required for querying all objects
         pod_id=dict(type='int'),
@@ -236,6 +242,7 @@ def main():
     )
 
     pod_id = module.params.get('pod_id')
+    annotation = module.params.get('annotation')
     serial = module.params.get('serial')
     node_id = module.params.get('node_id')
     switch = module.params.get('switch')

--- a/plugins/modules/aci_fabric_scheduler.py
+++ b/plugins/modules/aci_fabric_scheduler.py
@@ -23,6 +23,11 @@ description:
     -   With the module you can create schedule policies that can be a shell, onetime execution or recurring
 
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   name:
     description:
     - The name of the Scheduler.
@@ -248,6 +253,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         name=dict(type='str', aliases=['name', 'scheduler_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         windowname=dict(type='str', aliases=['windowname']),
@@ -273,6 +279,7 @@ def main():
     )
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     name = module.params.get('name')
     windowname = module.params.get('windowname')
     recurring = module.params.get('recurring')

--- a/plugins/modules/aci_filter.py
+++ b/plugins/modules/aci_filter.py
@@ -18,6 +18,11 @@ description:
 - Manages top level filter objects on Cisco ACI fabrics.
 - This modules does not manage filter entries, see M(aci_filter_entry) for this functionality.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   filter:
     description:
     - The name of the filter.
@@ -217,6 +222,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         filter=dict(type='str', aliases=['name', 'filter_name']),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -234,6 +240,7 @@ def main():
     )
 
     filter_name = module.params.get('filter')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     tenant = module.params.get('tenant')

--- a/plugins/modules/aci_filter_entry.py
+++ b/plugins/modules/aci_filter_entry.py
@@ -17,6 +17,11 @@ short_description: Manage filter entries (vz:Entry)
 description:
 - Manage filter entries for a filter on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   arp_flag:
     description:
     - The arp flag to use when the ether_type is arp.
@@ -258,6 +263,7 @@ ICMP6_MAPPING = dict(dst_unreachable='dst-unreach', echo_request='echo-req', ech
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         arp_flag=dict(type='str', choices=VALID_ARP_FLAGS),
         description=dict(type='str', aliases=['descr']),
         dst_port=dict(type='str'),
@@ -287,6 +293,7 @@ def main():
     aci = ACIModule(module)
 
     arp_flag = module.params.get('arp_flag')
+    annotation = module.params.get('annotation')
     if arp_flag is not None:
         arp_flag = ARP_FLAG_MAPPING.get(arp_flag)
     description = module.params.get('description')

--- a/plugins/modules/aci_firmware_group.py
+++ b/plugins/modules/aci_firmware_group.py
@@ -21,6 +21,11 @@ short_description: This module creates a firmware group
 description:
     - This module creates a firmware group, so that you can apply firmware policy to nodes.
 options:
+    annotation:
+        description:
+            - User-defined string for annotating the MO.
+        type: str
+        required: no
     group:
         description:
             - This the name of the firmware group
@@ -174,6 +179,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         group=dict(type='str', aliases=['group']),  # Not required for querying all objects
         firmwarepol=dict(type='str'),  # Not required for querying all objects
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
@@ -190,6 +196,7 @@ def main():
     )
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     group = module.params.get('group')
     firmwarepol = module.params.get('firmwarepol')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_firmware_group_node.py
+++ b/plugins/modules/aci_firmware_group_node.py
@@ -44,6 +44,11 @@ options:
         description:
             - The alias for the current object. This relates to the nameAlias field in ACI.
         type: str
+    annotation:
+        description:
+            - User-defined string for annotating the MO.
+        type: str
+        required: no
 extends_documentation_fragment:
 - cisco.aci.aci
 
@@ -190,6 +195,7 @@ def main():
         node=dict(type='str', aliases=['node']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         name_alias=dict(type='str'),
+        annotation=dict(type='str'),  # Not required for querying all objects
     )
 
     module = AnsibleModule(
@@ -202,6 +208,7 @@ def main():
     )
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     group = module.params.get('group')
     node = module.params.get('node')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_firmware_policy.py
+++ b/plugins/modules/aci_firmware_policy.py
@@ -25,6 +25,11 @@ description:
     - referenced by the firmware group. You will assign the firmware and specify if you want to ignore the compatibility
     - check
 options:
+    annotation:
+        description:
+            - User-defined string for annotating the MO.
+        type: str
+        required: no
     name:
         description:
             - Name of the firmware policy
@@ -189,6 +194,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         name=dict(type='str', aliases=['name']),  # Not required for querying all objects
         version=dict(type='str', aliases=['version']),
         ignoreCompat=dict(type='bool'),
@@ -206,6 +212,7 @@ def main():
     )
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     name = module.params.get('name')
     version = module.params.get('version')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_firmware_source.py
+++ b/plugins/modules/aci_firmware_source.py
@@ -18,6 +18,11 @@ short_description: Manage firmware image sources (firmware:OSource)
 description:
 - Manage firmware image sources on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   source:
     description:
     - The identifying name for the outside source of images, such as an HTTP or SCP server.
@@ -223,6 +228,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         source=dict(type='str', aliases=['name', 'source_name']),  # Not required for querying all objects
         polling_interval=dict(type='int'),
         url=dict(type='str'),
@@ -243,6 +249,7 @@ def main():
     )
 
     polling_interval = module.params.get('polling_interval')
+    annotation = module.params.get('annotation')
     url_protocol = module.params.get('url_protocol')
     state = module.params.get('state')
     source = module.params.get('source')

--- a/plugins/modules/aci_interface_policy_cdp.py
+++ b/plugins/modules/aci_interface_policy_cdp.py
@@ -19,6 +19,11 @@ short_description: Manage CDP interface policies (cdp:IfPol)
 description:
 - Manage CDP interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   cdp_policy:
     description:
     - The CDP interface policy name.
@@ -197,6 +202,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         cdp_policy=dict(type='str', required=False, aliases=['cdp_interface', 'name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         admin_state=dict(type='bool'),
@@ -216,6 +222,7 @@ def main():
     aci = ACIModule(module)
 
     cdp_policy = module.params.get('cdp_policy')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     admin_state = aci.boolean(module.params.get('admin_state'), 'enabled', 'disabled')
     state = module.params.get('state')

--- a/plugins/modules/aci_interface_policy_fc.py
+++ b/plugins/modules/aci_interface_policy_fc.py
@@ -17,6 +17,11 @@ short_description: Manage Fibre Channel interface policies (fc:IfPol)
 description:
 - Manage ACI Fiber Channel interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   fc_policy:
     description:
     - The name of the Fiber Channel interface policy.
@@ -182,6 +187,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         fc_policy=dict(type='str', aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         port_mode=dict(type='str', choices=['f', 'np']),  # No default provided on purpose
@@ -199,6 +205,7 @@ def main():
     )
 
     fc_policy = module.params.get('fc_policy')
+    annotation = module.params.get('annotation')
     port_mode = module.params.get('port_mode')
     description = module.params.get('description')
     state = module.params.get('state')

--- a/plugins/modules/aci_interface_policy_l2.py
+++ b/plugins/modules/aci_interface_policy_l2.py
@@ -17,6 +17,11 @@ short_description: Manage Layer 2 interface policies (l2:IfPol)
 description:
 - Manage Layer 2 interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   l2_policy:
     description:
     - The name of the Layer 2 interface policy.
@@ -199,6 +204,7 @@ QINQ_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         l2_policy=dict(type='str', aliases=['name']),  # Not required for querying all policies
         description=dict(type='str', aliases=['descr']),
         vlan_scope=dict(type='str', choices=['global', 'portlocal']),  # No default provided on purpose
@@ -220,6 +226,7 @@ def main():
     aci = ACIModule(module)
 
     l2_policy = module.params.get('l2_policy')
+    annotation = module.params.get('annotation')
     vlan_scope = module.params.get('vlan_scope')
     qinq = module.params.get('qinq')
     if qinq is not None:

--- a/plugins/modules/aci_interface_policy_leaf_policy_group.py
+++ b/plugins/modules/aci_interface_policy_leaf_policy_group.py
@@ -18,6 +18,11 @@ short_description: Manage fabric interface policy leaf policy groups (infra:AccB
 description:
 - Manage fabric interface policy leaf policy groups on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   policy_group:
     description:
     - Name of the leaf policy group to be added/deleted.
@@ -325,6 +330,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         # NOTE: Since this module needs to include both infra:AccBndlGrp (for PC and VPC) and infra:AccPortGrp (for leaf access port policy group):
         # NOTE: I'll allow the user to make the choice here (link(PC), node(VPC), leaf(leaf-access port policy group))
         lag_type=dict(type='str', required=True, aliases=['lag_type_name'], choices=['leaf', 'link', 'node']),
@@ -360,6 +366,7 @@ def main():
     )
 
     policy_group = module.params.get('policy_group')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     lag_type = module.params.get('lag_type')
     link_level_policy = module.params.get('link_level_policy')

--- a/plugins/modules/aci_interface_policy_leaf_profile.py
+++ b/plugins/modules/aci_interface_policy_leaf_profile.py
@@ -18,6 +18,11 @@ short_description: Manage fabric interface policy leaf profiles (infra:AccPortP)
 description:
 - Manage fabric interface policy leaf profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   leaf_interface_profile:
     description:
     - The name of the Fabric access policy leaf interface profile.
@@ -202,6 +207,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         leaf_interface_profile=dict(type='str', aliases=['name', 'leaf_interface_profile_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
@@ -218,6 +224,7 @@ def main():
     )
 
     leaf_interface_profile = module.params.get('leaf_interface_profile')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_interface_policy_lldp.py
+++ b/plugins/modules/aci_interface_policy_lldp.py
@@ -17,6 +17,11 @@ short_description: Manage LLDP interface policies (lldp:IfPol)
 description:
 - Manage LLDP interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   lldp_policy:
     description:
     - The LLDP interface policy name.
@@ -186,6 +191,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         lldp_policy=dict(type='str', aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         receive_state=dict(type='bool'),
@@ -206,6 +212,7 @@ def main():
     aci = ACIModule(module)
 
     lldp_policy = module.params.get('lldp_policy')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     receive_state = aci.boolean(module.params.get('receive_state'), 'enabled', 'disabled')
     transmit_state = aci.boolean(module.params.get('transmit_state'), 'enabled', 'disabled')

--- a/plugins/modules/aci_interface_policy_mcp.py
+++ b/plugins/modules/aci_interface_policy_mcp.py
@@ -17,6 +17,11 @@ short_description: Manage MCP interface policies (mcp:IfPol)
 description:
 - Manage MCP interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   mcp:
     description:
     - The name of the MCP interface.
@@ -180,6 +185,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         mcp=dict(type='str', aliases=['mcp_interface', 'name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         admin_state=dict(type='bool'),
@@ -199,6 +205,7 @@ def main():
     aci = ACIModule(module)
 
     mcp = module.params.get('mcp')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     admin_state = aci.boolean(module.params.get('admin_state'), 'enabled', 'disabled')
     state = module.params.get('state')

--- a/plugins/modules/aci_interface_policy_ospf.py
+++ b/plugins/modules/aci_interface_policy_ospf.py
@@ -18,6 +18,11 @@ short_description: Manage OSPF interface policies (ospf:IfPol)
 description:
 - Manage OSPF interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - The name of the Tenant the OSPF interface policy should belong to.
@@ -297,6 +302,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         ospf=dict(type='str', aliases=['ospf_interface', 'name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -325,6 +331,7 @@ def main():
     aci = ACIModule(module)
 
     tenant = module.params.get('tenant')
+    annotation = module.params.get('annotation')
     ospf = module.params.get('ospf')
     description = module.params.get('description')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_interface_policy_port_channel.py
+++ b/plugins/modules/aci_interface_policy_port_channel.py
@@ -17,6 +17,11 @@ short_description: Manage port channel interface policies (lacp:LagPol)
 description:
 - Manage port channel interface policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   port_channel:
     description:
     - Name of the port channel.
@@ -231,6 +236,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         port_channel=dict(type='str', aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         min_links=dict(type='int'),
@@ -255,6 +261,7 @@ def main():
     )
 
     port_channel = module.params.get('port_channel')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     min_links = module.params.get('min_links')
     if min_links is not None and min_links not in range(1, 17):

--- a/plugins/modules/aci_interface_policy_port_security.py
+++ b/plugins/modules/aci_interface_policy_port_security.py
@@ -17,6 +17,11 @@ short_description: Manage port security (l2:PortSecurityPol)
 description:
 - Manage port security on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   port_security:
     description:
     - The name of the port security.
@@ -188,6 +193,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         port_security=dict(type='str', aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         max_end_points=dict(type='int'),
@@ -206,6 +212,7 @@ def main():
     )
 
     port_security = module.params.get('port_security')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     max_end_points = module.params.get('max_end_points')
     port_security_timeout = module.params.get('port_security_timeout')

--- a/plugins/modules/aci_interface_selector_to_switch_policy_leaf_profile.py
+++ b/plugins/modules/aci_interface_selector_to_switch_policy_leaf_profile.py
@@ -18,6 +18,11 @@ short_description: Bind interface selector profiles to switch policy leaf profil
 description:
 - Bind interface selector profiles to switch policy leaf profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   leaf_profile:
     description:
     - Name of the Leaf Profile to which we add a Selector.
@@ -194,6 +199,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         leaf_profile=dict(type='str', aliases=['leaf_profile_name']),  # Not required for querying all objects
         interface_selector=dict(type='str', aliases=['interface_profile_name', 'interface_selector_name', 'name']),  # Not required for querying all objects
         state=dict(type='str', default='present', choices=['absent', 'present', 'query'])
@@ -209,6 +215,7 @@ def main():
     )
 
     leaf_profile = module.params.get('leaf_profile')
+    annotation = module.params.get('annotation')
     # WARNING: interface_selector accepts non existing interface_profile names and they appear on APIC gui with a state of "missing-target"
     interface_selector = module.params.get('interface_selector')
     state = module.params.get('state')

--- a/plugins/modules/aci_l3out.py
+++ b/plugins/modules/aci_l3out.py
@@ -17,6 +17,11 @@ short_description: Manage Layer 3 Outside (L3Out) objects (l3ext:Out)
 description:
 - Manage Layer 3 Outside (L3Out) on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - Name of an existing tenant.
@@ -247,6 +252,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         l3out=dict(type='str', aliases=['l3out_name', 'name']),  # Not required for querying all objects
         domain=dict(type='str', aliases=['ext_routed_domain_name', 'routed_domain']),
@@ -275,6 +281,7 @@ def main():
     aci = ACIModule(module)
 
     l3out = module.params.get('l3out')
+    annotation = module.params.get('annotation')
     domain = module.params.get('domain')
     dscp = module.params.get('dscp')
     description = module.params.get('description')

--- a/plugins/modules/aci_l3out_extepg.py
+++ b/plugins/modules/aci_l3out_extepg.py
@@ -17,6 +17,11 @@ short_description: Manage External Network Instance Profile (ExtEpg) objects (l3
 description:
 - Manage External Network Instance Profile (ExtEpg) objects (l3extInstP:instP)
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - Name of an existing tenant.
@@ -230,6 +235,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         l3out=dict(type='str', aliases=['l3out_name']),  # Not required for querying all objects
         extepg=dict(type='str', aliases=['extepg_name', 'name']),  # Not required for querying all objects
@@ -255,6 +261,7 @@ def main():
     aci = ACIModule(module)
 
     tenant = module.params.get('tenant')
+    annotation = module.params.get('annotation')
     l3out = module.params.get('l3out')
     extepg = module.params.get('extepg')
     description = module.params.get('description')

--- a/plugins/modules/aci_l3out_extsubnet.py
+++ b/plugins/modules/aci_l3out_extsubnet.py
@@ -17,6 +17,11 @@ short_description: Manage External Subnet objects (l3extSubnet:extsubnet)
 description:
 - Manage External Subnet objects (l3extSubnet:extsubnet)
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - Name of an existing tenant.
@@ -243,6 +248,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         l3out=dict(type='str', aliases=['l3out_name']),  # Not required for querying all objects
         extepg=dict(type='str', aliases=['extepg_name', 'name']),  # Not required for querying all objects
@@ -266,6 +272,7 @@ def main():
     aci = ACIModule(module)
 
     tenant = module.params.get('tenant')
+    annotation = module.params.get('annotation')
     l3out = module.params.get('l3out')
     extepg = module.params.get('extepg')
     network = module.params.get('network')

--- a/plugins/modules/aci_l3out_route_tag_policy.py
+++ b/plugins/modules/aci_l3out_route_tag_policy.py
@@ -17,6 +17,11 @@ short_description: Manage route tag policies (l3ext:RouteTagPol)
 description:
 - Manage route tag policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   rtp:
     description:
     - The name of the route tag policy.
@@ -191,6 +196,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         rtp=dict(type='str', aliases=['name', 'rtp_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -209,6 +215,7 @@ def main():
     )
 
     rtp = module.params.get('rtp')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     tag = module.params.get('tag')
     state = module.params.get('state')

--- a/plugins/modules/aci_maintenance_group.py
+++ b/plugins/modules/aci_maintenance_group.py
@@ -20,6 +20,11 @@ notes:
 description:
     - This modules creates an ACI maintenance group
 options:
+    annotation:
+        description:
+            - User-defined string for annotating the MO.
+        type: str
+        required: no
     group:
         description:
             - This is the name of the group
@@ -173,6 +178,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         group=dict(type='str'),  # Not required for querying all objects
         policy=dict(type='str'),  # Not required for querying all objects
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
@@ -189,6 +195,7 @@ def main():
     )
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     group = module.params.get('group')
     policy = module.params.get('policy')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_maintenance_group_node.py
+++ b/plugins/modules/aci_maintenance_group_node.py
@@ -18,6 +18,11 @@ short_description: Manage maintenance group nodes
 description:
 - Manage maintenance group nodes
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   group:
     description:
     - The maintenance group name that you want to add the node to.
@@ -182,6 +187,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         group=dict(type='str'),  # Not required for querying all objects
         node=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
@@ -198,6 +204,7 @@ def main():
     )
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     group = module.params.get('group')
     node = module.params.get('node')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_maintenance_policy.py
+++ b/plugins/modules/aci_maintenance_policy.py
@@ -19,6 +19,11 @@ short_description: Manage firmware maintenance policies
 description:
 - Manage maintenance policies that defines behavior during an ACI upgrade.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   name:
     description:
     - The name for the maintenance policy.
@@ -199,6 +204,7 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         name=dict(type='str', aliases=['maintenance_policy']),  # Not required for querying all objects
         runmode=dict(type='str', default='pauseOnlyOnFailures', choices=['pauseOnlyOnFailures', 'pauseNever']),
         graceful=dict(type='bool'),
@@ -221,6 +227,7 @@ def main():
     aci = ACIModule(module)
 
     state = module.params.get('state')
+    annotation = module.params.get('annotation')
     name = module.params.get('name')
     runmode = module.params.get('runmode')
     scheduler = module.params.get('scheduler')

--- a/plugins/modules/aci_static_binding_to_epg.py
+++ b/plugins/modules/aci_static_binding_to_epg.py
@@ -18,6 +18,11 @@ short_description: Bind static paths to EPGs (fv:RsPathAtt)
 description:
 - Bind static paths to EPGs on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - Name of an existing tenant.
@@ -305,6 +310,7 @@ INTERFACE_TYPE_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         ap=dict(type='str', aliases=['app_profile', 'app_profile_name']),  # Not required for querying all objects
         epg=dict(type='str', aliases=['epg_name']),  # Not required for querying all objects
@@ -333,6 +339,7 @@ def main():
     )
 
     tenant = module.params.get('tenant')
+    annotation = module.params.get('annotation')
     ap = module.params.get('ap')
     epg = module.params.get('epg')
     description = module.params.get('description')

--- a/plugins/modules/aci_switch_leaf_selector.py
+++ b/plugins/modules/aci_switch_leaf_selector.py
@@ -18,6 +18,11 @@ short_description: Bind leaf selectors to switch policy leaf profiles (infra:Lea
 description:
 - Bind leaf selectors (with node block range and policy group) to switch policy leaf profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   description:
     description:
     - The description to assign to the C(leaf).
@@ -245,6 +250,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update({
+        'annotation': dict(type='str'),  # Not required for querying all objects
         'description': dict(type='str'),
         'leaf_profile': dict(type='str', aliases=['leaf_profile_name']),  # Not required for querying all objects
         'leaf': dict(type='str', aliases=['name', 'leaf_name', 'leaf_profile_leaf_name', 'leaf_selector_name']),  # Not required for querying all objects
@@ -268,6 +274,7 @@ def main():
     )
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     leaf_profile = module.params.get('leaf_profile')
     leaf = module.params.get('leaf')
     leaf_node_blk = module.params.get('leaf_node_blk')

--- a/plugins/modules/aci_switch_policy_leaf_profile.py
+++ b/plugins/modules/aci_switch_policy_leaf_profile.py
@@ -18,6 +18,11 @@ short_description: Manage switch policy leaf profiles (infra:NodeP)
 description:
 - Manage switch policy leaf profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   leaf_profile:
     description:
     - The name of the Leaf Profile.
@@ -194,6 +199,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         leaf_profile=dict(type='str', aliases=['name', 'leaf_profile_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
@@ -210,6 +216,7 @@ def main():
     )
 
     leaf_profile = module.params.get('leaf_profile')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_switch_policy_vpc_protection_group.py
+++ b/plugins/modules/aci_switch_policy_vpc_protection_group.py
@@ -18,6 +18,11 @@ short_description: Manage switch policy explicit vPC protection groups (fabric:E
 description:
 - Manage switch policy explicit vPC protection groups on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   protection_group:
     description:
     - The name of the Explicit vPC Protection Group.
@@ -222,6 +227,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         protection_group=dict(type='str', aliases=['name', 'protection_group_name']),  # Not required for querying all objects
         protection_group_id=dict(type='int', aliases=['id']),
         vpc_domain_policy=dict(type='str', aliases=['vpc_domain_policy_name']),
@@ -241,6 +247,7 @@ def main():
     )
 
     protection_group = module.params.get('protection_group')
+    annotation = module.params.get('annotation')
     protection_group_id = module.params.get('protection_group_id')
     vpc_domain_policy = module.params.get('vpc_domain_policy')
     switch_1_id = module.params.get('switch_1_id')

--- a/plugins/modules/aci_taboo_contract.py
+++ b/plugins/modules/aci_taboo_contract.py
@@ -18,6 +18,11 @@ short_description: Manage taboo contracts (vz:BrCP)
 description:
 - Manage taboo contracts on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   taboo_contract:
     description:
     - The name of the Taboo Contract.
@@ -221,6 +226,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         taboo_contract=dict(type='str', aliases=['name']),  # Not required for querying all contracts
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all contracts
         scope=dict(type='str', choices=['application-profile', 'context', 'global', 'tenant']),
@@ -239,6 +245,7 @@ def main():
     )
 
     taboo_contract = module.params.get('taboo_contract')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     scope = module.params.get('scope')
     state = module.params.get('state')

--- a/plugins/modules/aci_tenant.py
+++ b/plugins/modules/aci_tenant.py
@@ -17,6 +17,11 @@ short_description: Manage tenants (fv:Tenant)
 description:
 - Manage tenants on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - The name of the tenant.
@@ -207,6 +212,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['name', 'tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
@@ -223,6 +229,7 @@ def main():
     )
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     state = module.params.get('state')
     tenant = module.params.get('tenant')
     name_alias = module.params.get('name_alias')

--- a/plugins/modules/aci_tenant_action_rule_profile.py
+++ b/plugins/modules/aci_tenant_action_rule_profile.py
@@ -17,6 +17,11 @@ short_description: Manage action rule profiles (rtctrl:AttrP)
 description:
 - Manage action rule profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   action_rule:
     description:
     - The name of the action rule profile.
@@ -182,6 +187,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         action_rule=dict(type='str', aliases=['action_rule_name', 'name']),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -199,6 +205,7 @@ def main():
     )
 
     action_rule = module.params.get('action_rule')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     tenant = module.params.get('tenant')

--- a/plugins/modules/aci_tenant_ep_retention_policy.py
+++ b/plugins/modules/aci_tenant_ep_retention_policy.py
@@ -17,6 +17,11 @@ short_description: Manage End Point (EP) retention protocol policies (fv:EpRetPo
 description:
 - Manage End Point (EP) retention protocol policies on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - The name of an existing tenant.
@@ -259,6 +264,7 @@ BOUNCE_TRIG_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         epr_policy=dict(type='str', aliases=['epr_name', 'name']),  # Not required for querying all objects
         bounce_age=dict(type='int'),
@@ -282,6 +288,7 @@ def main():
     )
 
     epr_policy = module.params.get('epr_policy')
+    annotation = module.params.get('annotation')
     bounce_age = module.params.get('bounce_age')
     if bounce_age is not None and bounce_age != 0 and bounce_age not in range(150, 65536):
         module.fail_json(msg="The bounce_age must be a value of 0 or between 150 and 65535")

--- a/plugins/modules/aci_tenant_span_dst_group.py
+++ b/plugins/modules/aci_tenant_span_dst_group.py
@@ -17,6 +17,11 @@ short_description: Manage SPAN destination groups (span:DestGrp)
 description:
 - Manage SPAN destination groups on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   dst_group:
     description:
     - The name of the SPAN destination group.
@@ -184,6 +189,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         dst_group=dict(type='str', aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -201,6 +207,7 @@ def main():
     )
 
     dst_group = module.params.get('dst_group')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     state = module.params.get('state')
     tenant = module.params.get('tenant')

--- a/plugins/modules/aci_tenant_span_src_group.py
+++ b/plugins/modules/aci_tenant_span_src_group.py
@@ -17,6 +17,11 @@ short_description: Manage SPAN source groups (span:SrcGrp)
 description:
 - Manage SPAN source groups on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   admin_state:
     description:
     - Enable or disable the span sources.
@@ -193,6 +198,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         src_group=dict(type='str', aliases=['name']),  # Not required for querying all objects
         admin_state=dict(type='bool'),
@@ -214,6 +220,7 @@ def main():
     aci = ACIModule(module)
 
     admin_state = aci.boolean(module.params.get('admin_state'), 'enabled', 'disabled')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     dst_group = module.params.get('dst_group')
     src_group = module.params.get('src_group')

--- a/plugins/modules/aci_tenant_span_src_group_to_dst_group.py
+++ b/plugins/modules/aci_tenant_span_src_group_to_dst_group.py
@@ -17,6 +17,11 @@ short_description: Bind SPAN source groups to destination groups (span:SpanLbl)
 description:
 - Bind SPAN source groups to associated destination groups on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   description:
     description:
     - The description for Span source group to destination group binding.
@@ -188,6 +193,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         dst_group=dict(type='str'),  # Not required for querying all objects
         src_group=dict(type='str'),  # Not required for querying all objects
@@ -206,6 +212,7 @@ def main():
     )
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     dst_group = module.params.get('dst_group')
     src_group = module.params.get('src_group')
     state = module.params.get('state')

--- a/plugins/modules/aci_vlan_pool.py
+++ b/plugins/modules/aci_vlan_pool.py
@@ -19,6 +19,11 @@ short_description: Manage VLAN pools (fvns:VlanInstP)
 description:
 - Manage VLAN pools on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   pool_allocation_mode:
     description:
     - The method used for allocating VLANs to resources.
@@ -215,6 +220,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         pool=dict(type='str', aliases=['name', 'pool_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         pool_allocation_mode=dict(type='str', aliases=['allocation_mode', 'mode'], choices=['dynamic', 'static']),
@@ -232,6 +238,7 @@ def main():
     )
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     pool = module.params.get('pool')
     pool_allocation_mode = module.params.get('pool_allocation_mode')
     state = module.params.get('state')

--- a/plugins/modules/aci_vlan_pool_encap_block.py
+++ b/plugins/modules/aci_vlan_pool_encap_block.py
@@ -19,6 +19,11 @@ short_description: Manage encap blocks assigned to VLAN pools (fvns:EncapBlk)
 description:
 - Manage VLAN encap blocks that are assigned to VLAN pools on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   allocation_mode:
     description:
     - The method used for allocating encaps to resources.
@@ -250,6 +255,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         pool=dict(type='str', aliases=['pool_name']),  # Not required for querying all objects
         block_name=dict(type='str', aliases=['name']),  # Not required for querying all objects
         block_end=dict(type='int', aliases=['end']),  # Not required for querying all objects
@@ -271,6 +277,7 @@ def main():
     )
 
     allocation_mode = module.params.get('allocation_mode')
+    annotation = module.params.get('annotation')
     description = module.params.get('description')
     pool = module.params.get('pool')
     pool_allocation_mode = module.params.get('pool_allocation_mode')

--- a/plugins/modules/aci_vmm_credential.py
+++ b/plugins/modules/aci_vmm_credential.py
@@ -17,6 +17,11 @@ short_description: Manage virtual domain credential profiles (vmm:UsrAccP)
 description:
 - Manage virtual domain credential profiles on Cisco ACI fabrics.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   name:
     description:
     - Name of the credential profile.
@@ -242,6 +247,7 @@ VM_PROVIDER_MAPPING = dict(
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         name=dict(type='str', aliases=['credential_name', 'credential_profile']),
         credential_password=dict(type='str', no_log=True),
         credential_username=dict(type='str'),
@@ -262,6 +268,7 @@ def main():
     )
 
     name = module.params.get('name')
+    annotation = module.params.get('annotation')
     credential_password = module.params.get('credential_password')
     credential_username = module.params.get('credential_username')
     description = module.params.get('description')

--- a/plugins/modules/aci_vrf.py
+++ b/plugins/modules/aci_vrf.py
@@ -18,6 +18,11 @@ description:
 - Manage contexts or VRFs on Cisco ACI fabrics.
 - Each context is a private network associated to a tenant, i.e. VRF.
 options:
+  annotation:
+    description:
+    - User-defined string for annotating the MO.
+    type: str
+    required: no
   tenant:
     description:
     - The name of the Tenant the VRF should belong to.
@@ -226,6 +231,7 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
+        annotation=dict(type='str'),  # Not required for querying all objects
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         vrf=dict(type='str', aliases=['context', 'name', 'vrf_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
@@ -245,6 +251,7 @@ def main():
     )
 
     description = module.params.get('description')
+    annotation = module.params.get('annotation')
     policy_control_direction = module.params.get('policy_control_direction')
     policy_control_preference = module.params.get('policy_control_preference')
     state = module.params.get('state')


### PR DESCRIPTION
Add the annotation field to all playbooks. This allows the annotation
field to be set on all configurable MOs. The annotation field is not
a required parameter.

closes CiscoDevNet/ansible-aci/issues/47