### PR TITLE
aci_cloud_zone module

### DIFF
--- a/plugins/modules/aci_cloud_zone.py
+++ b/plugins/modules/aci_cloud_zone.py
@@ -48,7 +48,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Query all zones under region
+- name: Query all zones in a region
   cisco.aci.aci_cloud_zone:
     host: apic
     username: userName
@@ -195,10 +195,10 @@ def main():
         supports_check_mode=True,
     )
 
-    name = module.params['name']
-    cloud = module.params['cloud']
-    region = module.params['region']
-    state = module.params['state']
+    name = module.params.get('name')
+    cloud = module.params.get('cloud')
+    region = module.params.get('region')
+    state = module.params.get('state')
 
     aci = ACIModule(module)
     aci.construct_url(

--- a/plugins/modules/aci_cloud_zone.py
+++ b/plugins/modules/aci_cloud_zone.py
@@ -29,7 +29,7 @@ options:
     type: str
   cloud:
     description:
-    - The vendor of the controller
+    - The cloud provider.
     choices: [ aws, azure ]
     type: str
   region:

--- a/plugins/modules/aci_cloud_zone.py
+++ b/plugins/modules/aci_cloud_zone.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: aci_cloudZone 
+short_description: Manage Cloud Availability Zone (cloud:Zone)
+description:
+- Mo doc not defined in techpub!!!
+notes:
+- More information about the internal APIC class B(cloud:Zone) from
+  L(the APIC Management Information Model reference,https://developer.cisco.com/docs/apic-mim-ref/).
+author:
+- Devarshi Shah (@devarshishah3)
+version_added: '2.7'
+options: 
+  annotation:
+    description:
+    - Mo doc not defined in techpub!!! 
+  name:
+    description:
+    - object name 
+    aliases: [ cloud_availability_zone ] 
+  nameAlias:
+    description:
+    - Mo doc not defined in techpub!!! 
+  cloud_provider_profile_vendor:
+    description:
+    - vendor of the controller 
+    choices: [ aws ] 
+  cloud_providers_region:
+    description:
+    - object name 
+  state: 
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    choices: [ absent, present, query ]
+    default: present 
+
+extends_documentation_fragment: aci
+'''
+
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update({ 
+        'annotation': dict(type='str',),
+        'name': dict(type='str', aliases=['cloud_availability_zone']),
+        'nameAlias': dict(type='str',),
+        'cloud_provider_profile_vendor': dict(type='str', choices=['aws'], ),
+        'cloud_providers_region': dict(type='str',),
+        'state': dict(type='str', default='present', choices=['absent', 'present', 'query']),
+
+    })
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[ 
+            ['state', 'absent', ['name', 'cloud_provider_profile_vendor', 'cloud_providers_region', ]], 
+            ['state', 'present', ['name', 'cloud_provider_profile_vendor', 'cloud_providers_region', ]],
+        ],
+    )
+    
+    annotation = module.params['annotation']
+    name = module.params['name']
+    nameAlias = module.params['nameAlias']
+    cloud_provider_profile_vendor = module.params['cloud_provider_profile_vendor']
+    cloud_providers_region = module.params['cloud_providers_region']
+    state = module.params['state']
+    child_configs=[]
+    
+
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class={
+            'aci_class': 'cloudProvP',
+            'aci_rn': 'clouddomp/provp-{}'.format(cloud_provider_profile_vendor),
+            'target_filter': 'eq(cloudProvP.vendor, "{}")'.format(cloud_provider_profile_vendor),
+            'module_object': cloud_provider_profile_vendor
+        }, 
+        subclass_1={
+            'aci_class': 'cloudRegion',
+            'aci_rn': 'region-{}'.format(cloud_providers_region),
+            'target_filter': 'eq(cloudRegion.name, "{}")'.format(cloud_providers_region),
+            'module_object': cloud_providers_region
+        }, 
+        subclass_2={
+            'aci_class': 'cloudZone',
+            'aci_rn': 'zone-{}'.format(name),
+            'target_filter': 'eq(cloudZone.name, "{}")'.format(name),
+            'module_object': name
+        }, 
+        
+        child_classes=[]
+        
+    )
+
+    aci.get_existing()
+
+    if state == 'present':
+        aci.payload(
+            aci_class='cloudZone',
+            class_config={ 
+                'annotation': annotation,
+                'name': name,
+                'nameAlias': nameAlias,
+            },
+            child_configs=child_configs
+           
+        )
+
+        aci.get_diff(aci_class='cloudZone')
+
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    aci.exit_json()
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aci_cloud_zone/aliases
+++ b/tests/integration/targets/aci_cloud_zone/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_cloud_zone/tasks/main.yml
+++ b/tests/integration/targets/aci_cloud_zone/tasks/main.yml
@@ -1,0 +1,90 @@
+# Test code for the ACI modules
+# Copyright: (c) 2020, Cindy Zhao (@cizhao) <cizhao@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+# CLEAN ENVIRONMENT
+- name: Set vars
+  set_fact:
+    mso_info: &mso_info
+      host: '{{ aws_aci_hostname }}'
+      username: '{{ aws_aci_username }}'
+      password: '{{ aws_aci_password }}'
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: '{{ aci_output_level | default("info") }}'
+
+- name: Query all zones under us-west-1
+  aci_cloud_zone:
+    <<: *mso_info
+    cloud: 'aws'
+    region: us-west-1
+    state: query
+  register: query_all
+
+- name: Verify query_all
+  assert:
+    that:
+    - query_all is not changed
+    - query_all.current.0.cloudRegion.attributes.name == "us-west-1"
+    - query_all.current.0.cloudRegion.children | length >= 2
+
+- name: Query a specific zone under region us-west-1
+  aci_cloud_zone:
+    <<: *mso_info
+    cloud: 'aws'
+    region: us-west-1
+    zone: us-west-1a
+    state: query
+  register: query_zone_1
+
+- name: Query another specific zone under region us-west-1
+  aci_cloud_zone:
+    <<: *mso_info
+    cloud: 'aws'
+    region: us-west-1
+    zone: us-west-1b
+    state: query
+  register: query_zone_2
+
+- name: Verify query_zone_1 and query_zone_2
+  assert:
+    that:
+    - query_zone_1 is not changed
+    - query_zone_2 is not changed
+    - query_zone_1.current.0.cloudZone.attributes.name == "us-west-1a"
+    - query_zone_1.current.0.cloudZone.attributes.dn == "uni/clouddomp/provp-aws/region-us-west-1/zone-us-west-1a"
+    - query_zone_2.current.0.cloudZone.attributes.name == "us-west-1b"
+    - query_zone_2.current.0.cloudZone.attributes.dn == "uni/clouddomp/provp-aws/region-us-west-1/zone-us-west-1b"
+
+- name: Query non_existing zone under region us-west-1
+  aci_cloud_zone:
+    <<: *mso_info
+    cloud: 'aws'
+    region: us-west-1
+    zone: non_existing
+    state: query
+  register: query_non_existing_zone
+
+- name: Query zone under non_existing region
+  aci_cloud_zone:
+    <<: *mso_info
+    cloud: 'aws'
+    region: non_existing
+    zone: us-west-1a
+    state: query
+  register: query_non_existing_region
+
+- name: Verify query_non_existing_zone
+  assert:
+    that:
+    - query_non_existing_zone is not changed
+    - query_non_existing_zone.current == []
+    - query_non_existing_region is not changed
+    - query_non_existing_region.current == []


### PR DESCRIPTION
- complete the 'aci_cloud_zone' module which is used to query cloud availability zone under the cloud region
- build test file for this query module
- tested in aws cloud apic (Version 5.0(2e))