### PR TITLE
[aci_l3out_extsubnet] fix issue of scope attribute not being specified

### DIFF
--- a/plugins/modules/aci_l3out_extsubnet.py
+++ b/plugins/modules/aci_l3out_extsubnet.py
@@ -22,16 +22,19 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
+    required: yes
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
+    required: yes
   extepg:
     description:
     - Name of an existing ExtEpg.
     type: str
     aliases: [ extepg_name ]
+    required: yes
   network:
     description:
     - The network address for the Subnet.
@@ -116,7 +119,7 @@ EXAMPLES = r'''
     state: absent
   delegate_to: localhost
 
-- name: Query ExtEpg information
+- name: Query ExtEpg Subnet information
   cisco.aci.aci_l3out_extsubnet:
     host: apic
     username: admin
@@ -242,9 +245,9 @@ from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, ac
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
-        tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
-        l3out=dict(type='str', aliases=['l3out_name']),  # Not required for querying all objects
-        extepg=dict(type='str', aliases=['extepg_name', 'name']),  # Not required for querying all objects
+        tenant=dict(type='str', required=True, aliases=['tenant_name']),
+        l3out=dict(type='str', required=True, aliases=['l3out_name']),
+        extepg=dict(type='str', required=True, aliases=['extepg_name', 'name']),
         network=dict(type='str', aliases=['address', 'ip']),
         description=dict(type='str', aliases=['descr']),
         subnet_name=dict(type='str', aliases=['name']),

--- a/plugins/modules/aci_l3out_extsubnet.py
+++ b/plugins/modules/aci_l3out_extsubnet.py
@@ -56,7 +56,6 @@ options:
     - The C(shared-rtctrl) option controls which external prefixes are advertised to other tenants for shared services.
     - The C(shared-security) option configures the classifier for the subnets in the VRF where the routes are leaked.
     - The APIC defaults to C(import-security) when unset during creation.
-    required: yes
     default: [ import-security ]
     type: list
     elements: str
@@ -249,7 +248,7 @@ def main():
         network=dict(type='str', aliases=['address', 'ip']),
         description=dict(type='str', aliases=['descr']),
         subnet_name=dict(type='str', aliases=['name']),
-        scope=dict(type='list', elements='str', required=True, default=['import-security'], choices=['export-rtctrl', 'import-security', 'shared-rtctrl', 'shared-security']),
+        scope=dict(type='list', elements='str', default=['import-security'], choices=['export-rtctrl', 'import-security', 'shared-rtctrl', 'shared-security']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         name_alias=dict(type='str'),
     )

--- a/plugins/modules/aci_l3out_extsubnet.py
+++ b/plugins/modules/aci_l3out_extsubnet.py
@@ -249,7 +249,7 @@ def main():
         network=dict(type='str', aliases=['address', 'ip']),
         description=dict(type='str', aliases=['descr']),
         subnet_name=dict(type='str', aliases=['name']),
-        scope=dict(type='list', elements='str', default=['import-security'], choices=['export-rtctrl', 'import-security', 'shared-rtctrl', 'shared-security']),
+        scope=dict(type='list', elements='str', required=True, default=['import-security'], choices=['export-rtctrl', 'import-security', 'shared-rtctrl', 'shared-security']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         name_alias=dict(type='str'),
     )

--- a/plugins/modules/aci_l3out_extsubnet.py
+++ b/plugins/modules/aci_l3out_extsubnet.py
@@ -56,6 +56,8 @@ options:
     - The C(shared-rtctrl) option controls which external prefixes are advertised to other tenants for shared services.
     - The C(shared-security) option configures the classifier for the subnets in the VRF where the routes are leaked.
     - The APIC defaults to C(import-security) when unset during creation.
+    required: yes
+    default: [ import-security ]
     type: list
     elements: str
     choices: [ export-rtctrl, import-security, shared-rtctrl, shared-security ]
@@ -85,6 +87,7 @@ seealso:
   link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Rostyslav Davydenko (@rost-d)
+- Cindy Zhao (@cizhao)
 '''
 
 EXAMPLES = r'''
@@ -246,7 +249,7 @@ def main():
         network=dict(type='str', aliases=['address', 'ip']),
         description=dict(type='str', aliases=['descr']),
         subnet_name=dict(type='str', aliases=['name']),
-        scope=dict(type='list', elements='str', choices=['export-rtctrl', 'import-security', 'shared-rtctrl', 'shared-security']),
+        scope=dict(type='list', elements='str', default=['import-security'], choices=['export-rtctrl', 'import-security', 'shared-rtctrl', 'shared-security']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         name_alias=dict(type='str'),
     )

--- a/tests/integration/targets/aci_l3out_extsubnet/aliases
+++ b/tests/integration/targets/aci_l3out_extsubnet/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_l3out_extsubnet/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_extsubnet/tasks/main.yml
@@ -54,12 +54,157 @@
     description: ExtEpg for Ansible l3out
     state: present
 
-- name: Add a subnet
+- name: Add a subnet (check mode)
   cisco.aci.aci_l3out_extsubnet:
     <<: *aci_info
     tenant: ansible_tenant
     l3out: ansible_l3out
     extepg: ansible_extEpg
     subnet_name: test
-    network: 0.0.0.0/0
+    network: 192.0.2.0/24
     state: present
+  check_mode: yes
+  register: cm_add_subnet
+
+- name: Add a subnet (normal mode)
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    subnet_name: test
+    network: 192.0.2.0/24
+    state: present
+  register: nm_add_subnet
+
+- name: Verify cm_add_subnet and nm_add_subnet
+  assert:
+    that:
+      - cm_add_subnet is changed
+      - nm_add_subnet is changed
+      - cm_add_subnet.proposed.l3extSubnet.attributes.ip == "192.0.2.0/24"
+      - cm_add_subnet.proposed.l3extSubnet.attributes.name == "test"
+      - cm_add_subnet.proposed.l3extSubnet.attributes.scope == "import-security"
+      - nm_add_subnet.current.0.l3extSubnet.attributes.ip == "192.0.2.0/24"
+      - nm_add_subnet.current.0.l3extSubnet.attributes.name == "test"
+      - nm_add_subnet.current.0.l3extSubnet.attributes.scope == "import-security"
+
+- name: Add subnet again
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    subnet_name: test
+    network: 192.0.2.0/24
+    state: present
+  register: nm_add_subnet_again
+
+- name: Verify nm_add_subnet_again
+  assert:
+    that:
+      - nm_add_subnet_again is not changed
+
+- name: Change subnet (check_mode)
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    network: 192.0.2.0/24
+    subnet_name: ansible_test
+    description: description for subnet
+    scope: [ shared-security, import-security ]
+    state: present
+  check_mode: yes
+  register: cm_change_subnet
+
+- name: Change subnet (check_mode)
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    network: 192.0.2.0/24
+    subnet_name: ansible_test
+    description: description for subnet
+    scope: [ shared-security, import-security ]
+    state: present
+  register: nm_change_subnet
+
+- name: Verify cm_change_subnet and nm_change_subnet
+  assert:
+    that:
+      - cm_change_subnet is changed
+      - nm_change_subnet is changed
+      - cm_change_subnet.previous.0.l3extSubnet.attributes.descr == nm_change_subnet.previous.0.l3extSubnet.attributes.descr == ""
+      - cm_change_subnet.previous.0.l3extSubnet.attributes.name == nm_change_subnet.previous.0.l3extSubnet.attributes.name == "test"
+      - cm_change_subnet.previous.0.l3extSubnet.attributes.scope == nm_change_subnet.previous.0.l3extSubnet.attributes.scope == "import-security"
+      - cm_change_subnet.proposed.l3extSubnet.attributes.descr == "description for subnet"
+      - cm_change_subnet.proposed.l3extSubnet.attributes.name == "ansible_test"
+      - cm_change_subnet.proposed.l3extSubnet.attributes.scope == "import-security,shared-security"
+      - nm_change_subnet.current.0.l3extSubnet.attributes.descr == "description for subnet"
+      - nm_change_subnet.current.0.l3extSubnet.attributes.name == "ansible_test"
+      - nm_change_subnet.current.0.l3extSubnet.attributes.scope == "import-security,shared-security"
+
+- name: Add another subnet (normal mode)
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    network: 192.1.2.0/24
+    state: present
+  register: nm_add_another_subnet
+
+- name: Verify nm_add_another_subnet
+  assert:
+    that:
+      - nm_add_another_subnet is changed
+      - nm_add_another_subnet.current.0.l3extSubnet.attributes.ip == "192.1.2.0/24"
+
+- name: Query all subnets
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    state: query
+  register: query_all
+
+- name: Query specific subnet
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    network: 192.0.2.0/24
+    state: query
+  register: query_subnet
+
+- name: Verify query_all and query_subnet
+  assert:
+    that:
+      - query_all is not changed
+      - query_subnet is not changed
+      - query_all.current.0.l3extInstP.children | length == 2
+      - query_subnet.current.0.l3extSubnet.attributes.name == "ansible_test"
+      - query_subnet.current.0.l3extSubnet.attributes.ip == "192.0.2.0/24"
+
+- name: Remove subnet
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    network: 192.0.2.0/24
+    state: absent
+  register: rm_subnet
+
+- name: Verify rm_subnet
+  assert:
+    that:
+      - rm_subnet is changed
+      - rm_subnet.current == []
+      - rm_subnet.previous.0.l3extSubnet.attributes.ip == "192.0.2.0/24"
+      - rm_subnet.previous.0.l3extSubnet.attributes.name == "ansible_test"

--- a/tests/integration/targets/aci_l3out_extsubnet/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_extsubnet/tasks/main.yml
@@ -1,0 +1,65 @@
+# Test code for the ACI modules
+# Copyright: (c) 2020, Cindy Zhao (@cizhao)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  set_fact: 
+   aci_info: &aci_info
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
+
+# CLEAN ENVIRONMENT
+- name: Remove the ansible_tenant
+  aci_tenant:
+    <<: *aci_info 
+    tenant: ansible_tenant
+    state: absent
+
+- name: Add a new tenant
+  aci_tenant:
+    <<: *aci_info 
+    tenant: ansible_tenant
+    description: Ansible tenant
+    state: present
+
+- name: Add a new l3out
+  aci_l3out:
+    <<: *aci_info
+    tenant: ansible_tenant
+    name: ansible_l3out
+    description: l3out for Ansible tenant
+    domain: ansible_dom
+    route_control: export
+    vrf: ansible_vrf
+    l3protocol: ospf
+    state: present
+
+- name: Add a new ExtEpg
+  aci_l3out_extepg:
+    <<: *aci_info 
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    name: ansible_extEpg
+    description: ExtEpg for Ansible l3out
+    state: present
+
+- name: Add a subnet
+  cisco.aci.aci_l3out_extsubnet:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    extepg: ansible_extEpg
+    subnet_name: test
+    network: 0.0.0.0/0
+    state: present


### PR DESCRIPTION
make 'scope' attribute default as 'import-security' to avoid crash

resolve #70 