### PR TITLE
Updated documentation fixes #30

### DIFF
--- a/plugins/modules/aci_rest.py
+++ b/plugins/modules/aci_rest.py
@@ -66,6 +66,7 @@ notes:
   This is a known APIC problem and has been reported to the vendor. A workaround for this issue exists.
   More information in :ref:`the ACI documentation <aci_guide_known_issues>`.
 - XML payloads require the C(lxml) and C(xmljson) python libraries. For JSON payloads nothing special is needed.
+- If you don’t have any attributes, it may be necessary to add: attributes: {} as the APIC does expect the entry to precede any children.
 seealso:
 - module: cisco.aci.aci_tenant
 - name: Cisco APIC REST API Configuration Guide


### PR DESCRIPTION
Update:
- If you don’t have any attributes, it may be necessary to add: attributes: {} as the APIC does expect the entry to precede any children.