### PR TITLE
existing_config variable is not reset during loop

### DIFF
--- a/plugins/module_utils/aci.py
+++ b/plugins/module_utils/aci.py
@@ -1029,6 +1029,7 @@ class ACIModule(object):
                     # Return the one that is a subset match
                     if set(proposed_config.items()).issubset(set(existing_config.items())):
                         break
+                    existing_config = None
 
         return child_class, proposed_config, existing_config
 


### PR DESCRIPTION
get_nested_config was always returning True if there was a matching child class, even if none of the attributes matched.