### PR TITLE
fix incorrect domain types

### DIFF
--- a/plugins/modules/aci_domain_to_encap_pool.py
+++ b/plugins/modules/aci_domain_to_encap_pool.py
@@ -315,11 +315,11 @@ def main():
         domain_class = 'fcDomP'
         domain_mo = 'uni/fc-{0}'.format(domain)
         domain_rn = 'fc-{0}'.format(domain)
-    elif domain_type == 'l2ext':
+    elif domain_type == 'l2dom':
         domain_class = 'l2extDomP'
         domain_mo = 'uni/l2dom-{0}'.format(domain)
         domain_rn = 'l2dom-{0}'.format(domain)
-    elif domain_type == 'l3ext':
+    elif domain_type == 'l3dom':
         domain_class = 'l3extDomP'
         domain_mo = 'uni/l3dom-{0}'.format(domain)
         domain_rn = 'l3dom-{0}'.format(domain)


### PR DESCRIPTION
According to documentation, the valid options for domain_type are fc, l2dom, l3dom, phys, and vmm. However, when building the full URL, l2ext and l3ext are compared against instead of l2dom and l3dom. This causes the error "UnboundLocalError: local variable 'domain_class' referenced before assignment" when trying to reference those domain types. 