### PR TITLE
Changed certificate_name to name for Query operations. fixes #101

### DIFF
--- a/plugins/modules/aci_aaa_user_certificate.py
+++ b/plugins/modules/aci_aaa_user_certificate.py
@@ -34,7 +34,7 @@ options:
     - The PEM format public key extracted from the X.509 certificate.
     type: str
     aliases: [ cert_data, certificate_data ]
-  certificate_name:
+  name:
     description:
     - The name of the user certificate entry in ACI.
     type: str
@@ -72,7 +72,7 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     aaa_user: admin
-    certificate_name: admin
+    name: admin
     certificate_data: '{{ lookup("file", "pki/admin.crt") }}'
     state: present
   delegate_to: localhost
@@ -83,7 +83,7 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     aaa_user: admin
-    certificate_name: admin
+    name: admin
     state: absent
   delegate_to: localhost
 
@@ -93,7 +93,7 @@ EXAMPLES = r'''
     username: admin
     password: SomeSecretPassword
     aaa_user: admin
-    certificate_name: admin
+    name: admin
     state: query
   delegate_to: localhost
   register: query_result
@@ -235,7 +235,7 @@ def main():
         aaa_user=dict(type='str', required=True),
         aaa_user_type=dict(type='str', default='user', choices=['appuser', 'user']),
         certificate=dict(type='str', aliases=['cert_data', 'certificate_data']),
-        certificate_name=dict(type='str', aliases=['cert_name']),  # Not required for querying all objects
+        name=dict(type='str'),  # Not required for querying all objects
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         name_alias=dict(type='str'),
     )
@@ -244,15 +244,15 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ['state', 'absent', ['aaa_user', 'certificate_name']],
-            ['state', 'present', ['aaa_user', 'certificate', 'certificate_name']],
+            ['state', 'absent', ['aaa_user', 'name']],
+            ['state', 'present', ['aaa_user', 'certificate', 'name']],
         ],
     )
 
     aaa_user = module.params.get('aaa_user')
     aaa_user_type = module.params.get('aaa_user_type')
     certificate = module.params.get('certificate')
-    certificate_name = module.params.get('certificate_name')
+    name = module.params.get('name')
     state = module.params.get('state')
     name_alias = module.params.get('name_alias')
 
@@ -266,9 +266,9 @@ def main():
         ),
         subclass_1=dict(
             aci_class='aaaUserCert',
-            aci_rn='usercert-{0}'.format(certificate_name),
-            module_object=certificate_name,
-            target_filter={'name': certificate_name},
+            aci_rn='usercert-{0}'.format(name),
+            module_object=name,
+            target_filter={'name': name},
         ),
     )
     aci.get_existing()
@@ -278,7 +278,7 @@ def main():
             aci_class='aaaUserCert',
             class_config=dict(
                 data=certificate,
-                name=certificate_name,
+                name=name,
                 nameAlias=name_alias,
 
             ),

--- a/tests/integration/network-integration.requirements.txt
+++ b/tests/integration/network-integration.requirements.txt
@@ -1,2 +1,3 @@
 lxml
 xmljson
+python-dateutil

--- a/tests/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/tests/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -8,9 +8,19 @@
     msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
   when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
 
+- name: Set vars
+  set_fact: 
+   aci_info: &aci_info
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
 
 # CLEAN ENVIRONMENT
-- name: Making sure running user has correct cert
+- name: Making sure current user has correct cert
   cisco.aci.aci_aaa_user_certificate:
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
@@ -20,7 +30,7 @@
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: '{{ aci_username }}'
-    certificate_name: admin
+    name: admin
     certificate: "{{ lookup('file', 'pki/admin.crt') }}"
     state: present
 
@@ -34,7 +44,7 @@
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: '{{ aci_username }}'
-    certificate_name: "{{ item }}"
+    name: "{{ item }}"
     state: absent
   loop:
     - admin
@@ -52,7 +62,7 @@
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: '{{ aci_username }}'
-    certificate_name: admin
+    name: admin
     certificate: "{{ lookup('file', 'pki/admin.crt') }}"
     state: present
   check_mode: yes
@@ -82,7 +92,7 @@
 - name: Add rsa_user certificates
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_present
-    certificate_name: "{{ item }}"
+    name: "{{ item }}"
     certificate: "{{ lookup('file', 'pki/rsa_user.crt') }}"
     state: present
   loop:
@@ -92,7 +102,7 @@
 - name: Add admin certificate with user name
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_present
-    certificate_name: '{{ aci_username }}'
+    name: '{{ aci_username }}'
     state: present
 
 # QUERY ALL USER CERTIFICATES
@@ -101,6 +111,7 @@
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
     #password: '{{ aci_password }}'
+    certificate_name: admin
     private_key: '{{ role_path }}/pki/admin.key'
     validate_certs: '{{ aci_validate_certs | default(false) }}'
     use_ssl: '{{ aci_use_ssl | default(true) }}'
@@ -127,6 +138,7 @@
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
     private_key: '{{ role_path }}/pki/rsa_user.key'
+    certificate_name: rsa_user
   register: nm_query_all_rsa
 
 - name: Verify nm_query_all_rsa
@@ -161,14 +173,14 @@
 - name: Query our certificate using signature-based authentication (check_mode)
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
-    certificate_name: admin
+    name: admin
   check_mode: yes
   register: cm_query_cert
 
 - name: Query our certificate using signature-based authentication (normal mode)
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
-    certificate_name: admin
+    name: admin
   register: nm_query_cert
 
 - name: Verify query_cert
@@ -182,7 +194,7 @@
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
     private_key: '{{ role_path }}/pki/admin_invalid.key'
-    certificate_name: admin
+    name: admin
   register: query_cert_invalid_key
   ignore_errors: yes
 
@@ -190,16 +202,16 @@
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
     private_key: '{{ role_path }}/pki/admin.crt'
-    certificate_name: admin
-  register: query_cert_invalid_key
+    name: admin
+  register: query_cert_valid_key
   ignore_errors: yes
-
 
 - name: Query our certificate using signature-based authentication (ansible rsa private key file)
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
     private_key: '{{ role_path }}/pki/rsa_ansible.key'
-    certificate_name: admin
+    certificate_name: rsa_user
+    name: rsa_user
   register: query_cert_openssh_rsa_key
   ignore_errors: yes
 
@@ -207,12 +219,12 @@
   cisco.aci.aci_aaa_user_certificate:
     <<: *cert_query
     private_key: '{{ role_path }}/pki/rsa_user.key'
-    certificate_name: "{{ item }}"
+    certificate_name: rsa_user
+    name: "{{ item }}"
   register: query_cert_ansible_rsa_key
   loop:
     - "rsa_user"
     - "user"
-    #- "admin"
 
 - name: Query our certificate using signature-based authentication (private key content for rsa_user certificate)
   cisco.aci.aci_aaa_user_certificate:
@@ -234,12 +246,12 @@
       /9beBPTS8cJdWHvCRE149H/ZCUxqjFZriJzFYvi0xor85eK8/3V7xaWtTkK25i3+
       xWk+sA3DYYDPGM8=
       -----END PRIVATE KEY-----
-    certificate_name: "{{ item }}"
+    certificate_name: rsa_user
+    name: "{{ item }}"
   register: query_cert_key_content
   loop:
     - "rsa_user"
     - "user"
-    #- "admin"
 
 # REMOVE CERTIFICATE
 - name: Remove certificate (check_mode)
@@ -252,7 +264,7 @@
     use_proxy: '{{ aci_use_proxy | default(true) }}'
     output_level: '{{ aci_output_level | default("info") }}'
     aaa_user: '{{ aci_username }}'
-    certificate_name: admin
+    name: admin
     state: absent
   check_mode: yes
   register: cm_remove_cert
@@ -277,3 +289,58 @@
     - nm_remove_cert is changed
     - cm_remove_cert_again is not changed
     - nm_remove_cert_again is not changed
+
+# Checking if changing certification_name to name throws an error. (#82)
+- name: Making sure current user has correct cert
+  aci_aaa_user_certificate:
+    <<: *aci_info
+    aaa_user: '{{ aci_username }}'
+    name: admin
+    certificate: "{{ lookup('file', 'pki/admin.crt') }}"
+    state: present
+
+- name: Remove user ansible_test
+  aci_aaa_user:
+      <<: *aci_info 
+      aaa_user: ansible_test
+      state: absent
+
+- name: Add user ansible_test
+  aci_aaa_user:
+    <<: *aci_info 
+    aaa_user: ansible_test
+    aaa_password: ansible_5351
+    expiration: never
+    expires: no
+    state: present
+
+- name: Add user certificate
+  aci_aaa_user_certificate:
+    <<: *aci_info 
+    aaa_user: ansible_test
+    name: test
+    certificate: "{{ lookup('file', 'pki/admin.crt') }}"
+    state: present
+
+- name: Query test certificate
+  aci_aaa_user_certificate:
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    certificate_name: admin
+    private_key: '{{ role_path }}/pki/admin.key'
+    aaa_user: ansible_test
+    name: test
+    state: query
+  register: query_test
+
+- name: Verify query_test
+  assert:
+    that:
+    - query_test is not changed
+
+- name: Remove user to clean environment for next test on ci
+  aci_aaa_user:
+    <<: *aci_info 
+    aaa_user: ansible_test
+    state: absent

--- a/tests/integration/targets/aci_aaa_user_certificate/tasks/main.yml
+++ b/tests/integration/targets/aci_aaa_user_certificate/tasks/main.yml
@@ -110,7 +110,6 @@
   cisco.aci.aci_aaa_user_certificate: &cert_query
     host: '{{ aci_hostname }}'
     username: '{{ aci_username }}'
-    #password: '{{ aci_password }}'
     certificate_name: admin
     private_key: '{{ role_path }}/pki/admin.key'
     validate_certs: '{{ aci_validate_certs | default(false) }}'


### PR DESCRIPTION
There was discrepancy with certificate_name as it was defined twice:
1. For username
2. For certificate's name
Fixed the issue by changing attribute name 'certificate_name' to name in the module.
