### PR TITLE
added route_profile, route_profile_l3_out to aci_bd

### DIFF
--- a/plugins/modules/aci_bd.py
+++ b/plugins/modules/aci_bd.py
@@ -139,7 +139,7 @@ options:
     description:
     - The Route Profile to associate with the Bridge Domain.
     type: str
-  route_profile_l3_out:
+  route_profile_l3out:
     description:
     - The L3 Out that contains the associated Route Profile.
     type: str
@@ -367,7 +367,7 @@ def main():
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         vrf=dict(type='str', aliases=['vrf_name']),
         route_profile=dict(type='str'),
-        route_profile_l3_out=dict(type='str'),
+        route_profile_l3out=dict(type='str'),
         name_alias=dict(type='str'),
     )
 
@@ -410,7 +410,7 @@ def main():
     tenant = module.params.get('tenant')
     vrf = module.params.get('vrf')
     route_profile = module.params.get('route_profile')
-    route_profile_l3_out = module.params.get('route_profile_l3_out')
+    route_profile_l3out = module.params.get('route_profile_l3out')
     name_alias = module.params.get('name_alias')
 
     aci.construct_url(
@@ -456,7 +456,7 @@ def main():
                 {'fvRsIgmpsn': {'attributes': {'tnIgmpSnoopPolName': igmp_snoop_policy}}},
                 {'fvRsBDToNdP': {'attributes': {'tnNdIfPolName': ipv6_nd_policy}}},
                 {'fvRsBdToEpRet': {'attributes': {'resolveAct': endpoint_retention_action, 'tnFvEpRetPolName': endpoint_retention_policy}}},
-                {'fvRsBDToProfile': {'attributes': {'tnL3extOutName': route_profile_l3_out, 'tnRtctrlProfileName': route_profile}}},
+                {'fvRsBDToProfile': {'attributes': {'tnL3extOutName': route_profile_l3out, 'tnRtctrlProfileName': route_profile}}},
             ],
         )
 

--- a/plugins/modules/aci_bd.py
+++ b/plugins/modules/aci_bd.py
@@ -135,6 +135,14 @@ options:
     - The name of the VRF.
     type: str
     aliases: [ vrf_name ]
+  route_profile:
+    description:
+    - The Route Profile to associate with the Bridge Domain.
+    type: str
+  route_profile_l3_out:
+    description:
+    - The L3 Out that contains the associated Route Profile.
+    type: str
 extends_documentation_fragment:
 - cisco.aci.aci
 
@@ -358,6 +366,8 @@ def main():
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         tenant=dict(type='str', aliases=['tenant_name']),  # Not required for querying all objects
         vrf=dict(type='str', aliases=['vrf_name']),
+        route_profile=dict(type='str'),
+        route_profile_l3_out=dict(type='str'),
         name_alias=dict(type='str'),
     )
 
@@ -399,6 +409,8 @@ def main():
     state = module.params.get('state')
     tenant = module.params.get('tenant')
     vrf = module.params.get('vrf')
+    route_profile = module.params.get('route_profile')
+    route_profile_l3_out = module.params.get('route_profile_l3_out')
     name_alias = module.params.get('name_alias')
 
     aci.construct_url(
@@ -414,7 +426,7 @@ def main():
             module_object=bd,
             target_filter={'name': bd},
         ),
-        child_classes=['fvRsCtx', 'fvRsIgmpsn', 'fvRsBDToNdP', 'fvRsBdToEpRet'],
+        child_classes=['fvRsCtx', 'fvRsIgmpsn', 'fvRsBDToNdP', 'fvRsBdToEpRet', 'fvRsBDToProfile'],
     )
 
     aci.get_existing()
@@ -444,6 +456,7 @@ def main():
                 {'fvRsIgmpsn': {'attributes': {'tnIgmpSnoopPolName': igmp_snoop_policy}}},
                 {'fvRsBDToNdP': {'attributes': {'tnNdIfPolName': ipv6_nd_policy}}},
                 {'fvRsBdToEpRet': {'attributes': {'resolveAct': endpoint_retention_action, 'tnFvEpRetPolName': endpoint_retention_policy}}},
+                {'fvRsBDToProfile': {'attributes': {'tnL3extOutName': route_profile_l3_out, 'tnRtctrlProfileName': route_profile}}},
             ],
         )
 

--- a/tests/integration/targets/aci_bd/tasks/main.yml
+++ b/tests/integration/targets/aci_bd/tasks/main.yml
@@ -39,6 +39,17 @@
     bd: anstest2
     state: absent
 
+- name: ensure L3out exists
+  cisco.aci.aci_l3out: &aci_l3_out_present
+    <<: *aci_tenant_present
+    tenant: anstest
+    l3out: ansible_l3out
+    domain: ansible_dom
+    route_control: export
+    vrf: anstest
+    l3protocol: ospf
+    state: present
+
 - name: create bd - check mode works
   cisco.aci.aci_bd: &aci_bd_present
     <<: *aci_tenant_present
@@ -68,12 +79,16 @@
   cisco.aci.aci_bd:
     <<: *aci_bd_present
     bd: anstest2
+    bd_type: ethernet
+    endpoint_move_detect: default
     ip_learning: "no"
     l2_unknown_unicast: flood
     l3_unknown_multicast: opt-flood
     multi_dest: drop
     enable_routing: "no"
     arp_flooding: "yes"
+    route_profile_l3out: ansible_l3out
+    route_profile: ansible_l3out_route
   register: bd_present_2
 
 - name: create bd without all necessary params - failure message works
@@ -107,6 +122,9 @@
       - bd_present_2.sent.fvBD.attributes.unicastRoute == 'no'
       - bd_present_2.sent.fvBD.attributes.unkMacUcastAct == 'flood'
       - bd_present_2.sent.fvBD.attributes.unkMcastAct == 'opt-flood'
+      - bd_present_2.sent.fvBD.attributes.type == 'regular'
+      - bd_present_2.sent.fvBD.children.0.fvRsBDToProfile.attributes.tnL3extOutName == 'ansible_l3out'
+      - bd_present_2.sent.fvBD.children.0.fvRsBDToProfile.attributes.tnRtctrlProfileName == 'ansible_l3out_route'
       - bd_present_missing_param is failed
       - 'bd_present_missing_param.msg == "state is present but all of the following are missing: tenant"'
 
@@ -141,22 +159,22 @@
       - query_all is not changed
       - query_all.current | length > 1
       - query_all.current.0.fvBD is defined
-      - '"rsp-subtree-class=fvRsBDToNdP,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_all.filter_string'
+      - '"rsp-subtree-class=fvRsBDToNdP,fvRsBDToProfile,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_all.filter_string'
       - '"class/fvBD.json" in query_all.url'
       - query_tenant is not changed
       - query_tenant.current | length == 1
       - query_tenant.current.0.fvTenant.children | length == 2
-      - '"rsp-subtree-class=fvBD,fvRsBDToNdP,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_tenant.filter_string'
+      - '"rsp-subtree-class=fvBD,fvRsBDToNdP,fvRsBDToProfile,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_tenant.filter_string'
       - '"tn-anstest.json" in query_tenant.url'
       - query_bd_bd is not changed
       - query_bd_bd.current != []
       - '"query-target-filter=eq(fvBD.name,\"anstest\")" in query_bd_bd.filter_string'
-      - '"rsp-subtree-class=fvRsBDToNdP,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_bd_bd.filter_string'
+      - '"rsp-subtree-class=fvRsBDToNdP,fvRsBDToProfile,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_bd_bd.filter_string'
       - '"class/fvBD.json" in query_bd_bd.url'
       - query_bd is not changed
       - query_bd.current | length == 1
       - query_bd.current.0.fvBD.attributes.name == "anstest"
-      - '"rsp-subtree-class=fvRsBDToNdP,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_bd.filter_string'
+      - '"rsp-subtree-class=fvRsBDToNdP,fvRsBDToProfile,fvRsBdToEpRet,fvRsCtx,fvRsIgmpsn" in query_bd.filter_string'
       - '"tn-anstest/BD-anstest.json" in query_bd.url'
 
 - name: delete bd - check mode works
@@ -205,6 +223,11 @@
     <<: *aci_vrf_present
     state: absent
   when: vrf_present is changed
+
+- name: delete l3out - cleanup before ending tests
+  cisco.aci.aci_l3out:
+    <<: *aci_l3_out_present
+    state: absent
 
 - name: delete tenant - cleanup before ending tests
   cisco.aci.aci_tenant:


### PR DESCRIPTION
I have added route_profile and route_profile_l3_out parameters to be able to configure both on Bridge Domain.
It was already available in aci_bd_subnet for Bridge Domain Subnet object.