### PR TITLE
aci_domain add support for vmm domain  infra port group and tag collection

### DIFF
--- a/plugins/modules/aci_domain.py
+++ b/plugins/modules/aci_domain.py
@@ -194,7 +194,7 @@ raw:
   returned: parse error
   type: str
   sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
-mo:
+sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info
   type: list

--- a/plugins/modules/aci_domain.py
+++ b/plugins/modules/aci_domain.py
@@ -46,6 +46,14 @@ options:
     - The layer 2 encapsulation protocol to use with the virtual switch.
     type: str
     choices: [ unknown, vlan, vxlan ]
+  add_infra_pg:
+    description:
+    - to configure port groups for infra VLAN (e.g. Virtual APIC).
+    type: bool
+  tag_collection:
+    description:
+    - Enables Cisco APIC to collect VMs that have been assigned tags in VMware vCenter for microsegmentation.
+    type: bool
   multicast_address:
     description:
     - The multicast IP address to use for the virtual switch.
@@ -186,7 +194,7 @@ raw:
   returned: parse error
   type: str
   sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
-sent:
+mo:
   description: The actual/minimal configuration pushed to the APIC
   returned: info
   type: list
@@ -277,6 +285,7 @@ VSWITCH_MAPPING = dict(
     unknown='unknown',
 )
 
+BOOL_TO_ACI_MAPPING = {True: 'yes', False: 'no', None: None}
 
 def main():
     argument_spec = aci_argument_spec()
@@ -288,6 +297,8 @@ def main():
                            'CS0', 'CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'EF', 'VA', 'unspecified'],
                   aliases=['target']),
         encap_mode=dict(type='str', choices=['unknown', 'vlan', 'vxlan']),
+        add_infra_pg=dict(type='bool'),
+        tag_collection=dict(type='bool'),
         multicast_address=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         vm_provider=dict(type='str', choices=['cloudfoundry', 'kubernetes', 'microsoft', 'openshift', 'openstack', 'redhat', 'vmware']),
@@ -309,6 +320,8 @@ def main():
     domain = module.params.get('domain')
     domain_type = module.params.get('domain_type')
     encap_mode = module.params.get('encap_mode')
+    add_infra_pg = BOOL_TO_ACI_MAPPING[module.params.get('add_infra_pg')]
+    tag_collection  = BOOL_TO_ACI_MAPPING[module.params.get('tag_collection')]
     multicast_address = module.params.get('multicast_address')
     vm_provider = module.params.get('vm_provider')
     vswitch = module.params.get('vswitch')
@@ -374,6 +387,8 @@ def main():
             class_config=dict(
                 encapMode=encap_mode,
                 mcastAddr=multicast_address,
+                configInfraPg=add_infra_pg,
+                enableTag=tag_collection,
                 mode=vswitch,
                 name=domain,
                 targetDscp=dscp,

--- a/plugins/modules/aci_domain.py
+++ b/plugins/modules/aci_domain.py
@@ -287,6 +287,7 @@ VSWITCH_MAPPING = dict(
 
 BOOL_TO_ACI_MAPPING = {True: 'yes', False: 'no', None: None}
 
+
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
@@ -321,7 +322,7 @@ def main():
     domain_type = module.params.get('domain_type')
     encap_mode = module.params.get('encap_mode')
     add_infra_pg = BOOL_TO_ACI_MAPPING[module.params.get('add_infra_pg')]
-    tag_collection  = BOOL_TO_ACI_MAPPING[module.params.get('tag_collection')]
+    tag_collection = BOOL_TO_ACI_MAPPING[module.params.get('tag_collection')]
     multicast_address = module.params.get('multicast_address')
     vm_provider = module.params.get('vm_provider')
     vswitch = module.params.get('vswitch')

--- a/plugins/modules/aci_domain.py
+++ b/plugins/modules/aci_domain.py
@@ -48,8 +48,9 @@ options:
     choices: [ unknown, vlan, vxlan ]
   add_infra_pg:
     description:
-    - to configure port groups for infra VLAN (e.g. Virtual APIC).
+    - Configure port groups for infra VLAN (e.g. Virtual APIC).
     type: bool
+    aliases: [ infra_pg ]
   tag_collection:
     description:
     - Enables Cisco APIC to collect VMs that have been assigned tags in VMware vCenter for microsegmentation.
@@ -298,7 +299,7 @@ def main():
                            'CS0', 'CS1', 'CS2', 'CS3', 'CS4', 'CS5', 'CS6', 'CS7', 'EF', 'VA', 'unspecified'],
                   aliases=['target']),
         encap_mode=dict(type='str', choices=['unknown', 'vlan', 'vxlan']),
-        add_infra_pg=dict(type='bool'),
+        add_infra_pg=dict(type='bool', aliases=['infra_pg']),
         tag_collection=dict(type='bool'),
         multicast_address=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),

--- a/tests/integration/targets/aci_domain/tasks/fc.yml
+++ b/tests/integration/targets/aci_domain/tasks/fc.yml
@@ -125,6 +125,13 @@
   ignore_errors: yes
   register: nm_incorrect_vswitch
 
+- name: Update FC domain with incorrect parameter dscp (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    dscp: unspecified
+  ignore_errors: yes
+  register: nm_incorrect_dscp
+
 - name: Verify incorrect parameter
   assert:
     that:
@@ -136,6 +143,7 @@
     - nm_incorrect_multicast_address.msg == "Domain type 'fc' cannot have parameter 'multicast_address'"
     - cm_incorrect_vswitch.msg == "Domain type 'fc' cannot have parameter 'vswitch'"
     - nm_incorrect_vswitch.msg == "Domain type 'fc' cannot have parameter 'vswitch'"
+    - nm_incorrect_dscp.msg == "DSCP values can only be assigned to 'l2ext and 'l3ext' domains"
 
 # QUERY ALL DOMAINS
 - name: Query all FC domains (check_mode)

--- a/tests/integration/targets/aci_domain/tasks/fc.yml
+++ b/tests/integration/targets/aci_domain/tasks/fc.yml
@@ -65,6 +65,77 @@
     - cm_add_domain_again is not changed
     - nm_add_domain_again is not changed
 
+- name: Update FC domain with incorrect parameter vm_provider (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vm_provider
+
+- name: Update FC domain with incorrect parameter vm_provider (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  ignore_errors: yes
+  register: nm_incorrect_vm_provider
+
+- name: Update FC domain with incorrect parameter encap_mode (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_encap_mode
+
+- name: Update FC domain with incorrect parameter encap_mode (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  ignore_errors: yes
+  register: nm_incorrect_encap_mode
+
+- name: Update FC domain with incorrect parameter multicast_address (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_multicast_address
+
+- name: Update FC domain with incorrect parameter multicast_address (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  ignore_errors: yes
+  register: nm_incorrect_multicast_address
+
+- name: Update FC domain with incorrect parameter vswitch (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vswitch
+
+- name: Update FC domain with incorrect parameter vswitch (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  ignore_errors: yes
+  register: nm_incorrect_vswitch
+
+- name: Verify incorrect parameter
+  assert:
+    that:
+    - cm_incorrect_vm_provider.msg == "Domain type 'fc' cannot have parameter 'vm_provider'"
+    - nm_incorrect_vm_provider.msg == "Domain type 'fc' cannot have parameter 'vm_provider'"
+    - cm_incorrect_encap_mode.msg == "Domain type 'fc' cannot have parameter 'encap_mode'"
+    - nm_incorrect_encap_mode.msg == "Domain type 'fc' cannot have parameter 'encap_mode'"
+    - cm_incorrect_multicast_address.msg == "Domain type 'fc' cannot have parameter 'multicast_address'"
+    - nm_incorrect_multicast_address.msg == "Domain type 'fc' cannot have parameter 'multicast_address'"
+    - cm_incorrect_vswitch.msg == "Domain type 'fc' cannot have parameter 'vswitch'"
+    - nm_incorrect_vswitch.msg == "Domain type 'fc' cannot have parameter 'vswitch'"
 
 # QUERY ALL DOMAINS
 - name: Query all FC domains (check_mode)

--- a/tests/integration/targets/aci_domain/tasks/l2dom.yml
+++ b/tests/integration/targets/aci_domain/tasks/l2dom.yml
@@ -65,6 +65,77 @@
     - cm_add_domain_again is not changed
     - nm_add_domain_again is not changed
 
+- name: Update L2 domain with incorrect parameter vm_provider (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vm_provider
+
+- name: Update L2 domain with incorrect parameter vm_provider (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  ignore_errors: yes
+  register: nm_incorrect_vm_provider
+
+- name: Update L2 domain with incorrect parameter encap_mode (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_encap_mode
+
+- name: Update L2 domain with incorrect parameter encap_mode (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  ignore_errors: yes
+  register: nm_incorrect_encap_mode
+
+- name: Update L2 domain with incorrect parameter multicast_address (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_multicast_address
+
+- name: Update L2 domain with incorrect parameter multicast_address (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  ignore_errors: yes
+  register: nm_incorrect_multicast_address
+
+- name: Update L2 domain with incorrect parameter vswitch (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vswitch
+
+- name: Update L2 domain with incorrect parameter vswitch (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  ignore_errors: yes
+  register: nm_incorrect_vswitch
+
+- name: Verify incorrect parameter
+  assert:
+    that:
+    - cm_incorrect_vm_provider.msg == "Domain type 'l2dom' cannot have parameter 'vm_provider'"
+    - nm_incorrect_vm_provider.msg == "Domain type 'l2dom' cannot have parameter 'vm_provider'"
+    - cm_incorrect_encap_mode.msg == "Domain type 'l2dom' cannot have parameter 'encap_mode'"
+    - nm_incorrect_encap_mode.msg == "Domain type 'l2dom' cannot have parameter 'encap_mode'"
+    - cm_incorrect_multicast_address.msg == "Domain type 'l2dom' cannot have parameter 'multicast_address'"
+    - nm_incorrect_multicast_address.msg == "Domain type 'l2dom' cannot have parameter 'multicast_address'"
+    - cm_incorrect_vswitch.msg == "Domain type 'l2dom' cannot have parameter 'vswitch'"
+    - nm_incorrect_vswitch.msg == "Domain type 'l2dom' cannot have parameter 'vswitch'"
 
 # QUERY ALL DOMAINS
 - name: Query all L2 domains (check_mode)

--- a/tests/integration/targets/aci_domain/tasks/l3dom.yml
+++ b/tests/integration/targets/aci_domain/tasks/l3dom.yml
@@ -65,6 +65,78 @@
     - cm_add_domain_again is not changed
     - nm_add_domain_again is not changed
 
+- name: Update L3 domain with incorrect parameter vm_provider (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vm_provider
+
+- name: Update L3 domain with incorrect parameter vm_provider (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  ignore_errors: yes
+  register: nm_incorrect_vm_provider
+
+- name: Update L3 domain with incorrect parameter encap_mode (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_encap_mode
+
+- name: Update L3 domain with incorrect parameter encap_mode (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  ignore_errors: yes
+  register: nm_incorrect_encap_mode
+
+- name: Update L3 domain with incorrect parameter multicast_address (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_multicast_address
+
+- name: Update L3 domain with incorrect parameter multicast_address (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  ignore_errors: yes
+  register: nm_incorrect_multicast_address
+
+- name: Update L3m domain with incorrect parameter vswitch (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vswitch
+
+- name: Update L3 domain with incorrect parameter vswitch (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  ignore_errors: yes
+  register: nm_incorrect_vswitch
+
+- name: Verify incorrect parameter
+  assert:
+    that:
+    - cm_incorrect_vm_provider.msg == "Domain type 'l3dom' cannot have parameter 'vm_provider'"
+    - nm_incorrect_vm_provider.msg == "Domain type 'l3dom' cannot have parameter 'vm_provider'"
+    - cm_incorrect_encap_mode.msg == "Domain type 'l3dom' cannot have parameter 'encap_mode'"
+    - nm_incorrect_encap_mode.msg == "Domain type 'l3dom' cannot have parameter 'encap_mode'"
+    - cm_incorrect_multicast_address.msg == "Domain type 'l3dom' cannot have parameter 'multicast_address'"
+    - nm_incorrect_multicast_address.msg == "Domain type 'l3dom' cannot have parameter 'multicast_address'"
+    - cm_incorrect_vswitch.msg == "Domain type 'l3dom' cannot have parameter 'vswitch'"
+    - nm_incorrect_vswitch.msg == "Domain type 'l3dom' cannot have parameter 'vswitch'"
+
 
 # QUERY ALL DOMAINS
 - name: Query all L3 domains (check_mode)

--- a/tests/integration/targets/aci_domain/tasks/phys.yml
+++ b/tests/integration/targets/aci_domain/tasks/phys.yml
@@ -65,6 +65,77 @@
     - cm_add_domain_again is not changed
     - nm_add_domain_again is not changed
 
+- name: Update physical domain with incorrect parameter vm_provider (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vm_provider
+
+- name: Update physical domain with incorrect parameter vm_provider (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vm_provider: vmware
+  ignore_errors: yes
+  register: nm_incorrect_vm_provider
+
+- name: Update physical domain with incorrect parameter encap_mode (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_encap_mode
+
+- name: Update physical domain with incorrect parameter encap_mode (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    encap_mode: vlan
+  ignore_errors: yes
+  register: nm_incorrect_encap_mode
+
+- name: Update physical domain with incorrect parameter multicast_address (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_multicast_address
+
+- name: Update physical domain with incorrect parameter multicast_address (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    multicast_address: 10.10.10.0
+  ignore_errors: yes
+  register: nm_incorrect_multicast_address
+
+- name: Update physical domain with incorrect parameter vswitch (check_mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  check_mode: yes
+  ignore_errors: yes
+  register: cm_incorrect_vswitch
+
+- name: Update physical domain with incorrect parameter vswitch (normal mode)
+  cisco.aci.aci_domain:
+    <<: *domain_present
+    vswitch: avs
+  ignore_errors: yes
+  register: nm_incorrect_vswitch
+
+- name: Verify incorrect parameter
+  assert:
+    that:
+    - cm_incorrect_vm_provider.msg == "Domain type 'phys' cannot have parameter 'vm_provider'"
+    - nm_incorrect_vm_provider.msg == "Domain type 'phys' cannot have parameter 'vm_provider'"
+    - cm_incorrect_encap_mode.msg == "Domain type 'phys' cannot have parameter 'encap_mode'"
+    - nm_incorrect_encap_mode.msg == "Domain type 'phys' cannot have parameter 'encap_mode'"
+    - cm_incorrect_multicast_address.msg == "Domain type 'phys' cannot have parameter 'multicast_address'"
+    - nm_incorrect_multicast_address.msg == "Domain type 'phys' cannot have parameter 'multicast_address'"
+    - cm_incorrect_vswitch.msg == "Domain type 'phys' cannot have parameter 'vswitch'"
+    - nm_incorrect_vswitch.msg == "Domain type 'phys' cannot have parameter 'vswitch'"
 
 # QUERY ALL DOMAINS
 - name: Query all physical domains (check_mode)

--- a/tests/integration/targets/aci_domain/tasks/vmm-vmware.yml
+++ b/tests/integration/targets/aci_domain/tasks/vmm-vmware.yml
@@ -78,6 +78,7 @@
       tag_collection: true
     check_mode: yes
     register: cm_update_domain
+    when: version.current.0.topSystem.attributes.version is version('4.1', '>=')
 
   - name: Update VMM domain with tag collection and infra port groups (normal mode)
     cisco.aci.aci_domain:
@@ -85,6 +86,7 @@
       add_infra_pg: true
       tag_collection: true
     register: nm_update_domain
+    when: version.current.0.topSystem.attributes.version is version('4.1', '>=')
 
   - name: Verify update_domain
     assert:
@@ -95,6 +97,7 @@
       - cm_update_domain.proposed.vmmDomP.attributes.configInfraPg == nm_update_domain.current.0.vmmDomP.attributes.configInfraPg == 'yes'
       - cm_update_domain.previous.0.vmmDomP.attributes.enableTag == nm_update_domain.previous.0.vmmDomP.attributes.enableTag == 'no'
       - cm_update_domain.proposed.vmmDomP.attributes.enableTag == nm_update_domain.current.0.vmmDomP.attributes.enableTag == 'yes'
+    when: version.current.0.topSystem.attributes.version is version('4.1', '>=')
 
   # QUERY ALL DOMAINS
   - name: Query all VMM domains (check_mode)

--- a/tests/integration/targets/aci_domain/tasks/vmm-vmware.yml
+++ b/tests/integration/targets/aci_domain/tasks/vmm-vmware.yml
@@ -70,7 +70,31 @@
       that:
       - cm_add_domain_again is not changed
       - nm_add_domain_again is not changed
+  
+  - name: Update VMM domain with tag collection and infra port groups (check_mode)
+    cisco.aci.aci_domain:
+      <<: *domain_present
+      add_infra_pg: true
+      tag_collection: true
+    check_mode: yes
+    register: cm_update_domain
 
+  - name: Update VMM domain with tag collection and infra port groups (normal mode)
+    cisco.aci.aci_domain:
+      <<: *domain_present
+      add_infra_pg: true
+      tag_collection: true
+    register: nm_update_domain
+
+  - name: Verify update_domain
+    assert:
+      that:
+      - cm_update_domain is changed
+      - nm_update_domain is changed
+      - cm_update_domain.previous.0.vmmDomP.attributes.configInfraPg == nm_update_domain.previous.0.vmmDomP.attributes.configInfraPg == 'no'
+      - cm_update_domain.proposed.vmmDomP.attributes.configInfraPg == nm_update_domain.current.0.vmmDomP.attributes.configInfraPg == 'yes'
+      - cm_update_domain.previous.0.vmmDomP.attributes.enableTag == nm_update_domain.previous.0.vmmDomP.attributes.enableTag == 'no'
+      - cm_update_domain.proposed.vmmDomP.attributes.enableTag == nm_update_domain.current.0.vmmDomP.attributes.enableTag == 'yes'
 
   # QUERY ALL DOMAINS
   - name: Query all VMM domains (check_mode)


### PR DESCRIPTION
This change partially addresses #29 adding support for  infrastructure port groups and tag collection on the vmm Domain.

I would plan to address the controller part via a new module named "aci_vmm_controller_to_domain"  working similar like  the existing "aci_vmm_credential"