### PR TITLE
add module aci_vmm_vswitch

### DIFF
--- a/plugins/module_utils/aci.py
+++ b/plugins/module_utils/aci.py
@@ -99,6 +99,29 @@ def aci_argument_spec():
     )
 
 
+def enhanced_lag_spec():
+    return dict(
+        name=dict(type='str', required=True),
+        lacp_mode=dict(type='str', choices=['active', 'passive']),
+        load_balancing_mode=dict(
+            type='str',
+            choices=['dst-ip', 'dst-ip-l4port', 'dst-ip-vlan', 'dst-ip-l4port-vlan', 'dst-mac', 'dst-l4port',
+                     'src-ip', 'src-ip-l4port', 'src-ip-vlan', 'src-ip-l4port-vlan', 'src-mac', 'src-l4port',
+                     'src-dst-ip', 'src-dst-ip-l4port', 'src-dst-ip-vlan', 'src-dst-ip-l4port-vlan', 'src-dst-mac',
+                     'src-dst-l4port', 'src-port-id', 'vlan']),
+        number_uplinks=dict(type='int'),
+    )
+
+
+def netflow_spec():
+    return dict(
+        name=dict(type='str', required=True),
+        active_flow_timeout=dict(type='int'),
+        idle_flow_timeout=dict(type='int'),
+        sampling_rate=dict(type='int'),
+    )
+
+
 class ACIModule(object):
 
     def __init__(self, module):

--- a/plugins/modules/aci_vmm_vswitch.py
+++ b/plugins/modules/aci_vmm_vswitch.py
@@ -1,0 +1,412 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Manuel Widmer <mawidmer@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_vmm_vswitch
+short_description: Manage vSwitch policy for VmWare virtual domains profiles (vmm:DomP)
+description:
+- Manage vSwitch policy for VmWare vmm domains on Cisco ACI fabrics.
+options:
+  port_channel_policy:
+    description:
+    - Name of the fabric access port-channel policy.
+    type: str
+  lldp_policy:
+    description:
+    - Name of the fabric access LLDP policy.
+    type: str
+  cdp_policy:
+    description:
+    - Name of the fabric access CDP policy.
+    type: str
+  mtu_policy:
+    description:
+    - Name of the fabric access MTU policy.
+    type: str
+  domain:
+    description:
+    - Name of the virtual domain profile.
+    type: str
+    aliases: [ domain_name, domain_profile, name ]
+    required: true
+  enhanced_lag:
+    description:
+    - List of enhanced LAG policies if vSwitch needs to be connected via VPC.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+        - Name of the enhanced Lag policy.
+        type: str
+        required: true
+      lacp_mode:
+        description:
+        - LACP port channel mode.
+        type: str
+        choices: [ active, passive ]
+      load_balancing_mode:
+        description:
+        - Load balancing mode of the port channel.
+        - See also https://pubhub.devnetcloud.com/media/apic-mim-ref-421/docs/MO-lacpEnhancedLagPol.html .
+        type: str
+        choices:
+          - dst-ip
+          - dst-ip-l4port
+          - dst-ip-vlan
+          - dst-ip-l4port-vlan
+          - dst-mac
+          - dst-l4port
+          - src-ip
+          - src-ip-l4port
+          - src-ip-vlan
+          - src-ip-l4port-vlan
+          - src-mac
+          - src-l4port
+          - src-dst-ip
+          - src-dst-ip-l4port
+          - src-dst-ip-vlan
+          - src-dst-ip-l4port-vlan
+          - src-dst-mac
+          - src-dst-l4port
+          - src-port-id
+          - vlan
+      number_uplinks:
+        description:
+        - Number of uplinks, must be between 2 and 8.
+        type: int
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+  name_alias:
+    description:
+    - The alias for the current object. This relates to the nameAlias field in ACI.
+    type: str
+  vm_provider:
+    description:
+    - The VM platform for VMM Domains.
+    - Support for Kubernetes was added in ACI v3.0.
+    - Support for CloudFoundry, OpenShift and Red Hat was added in ACI v3.1.
+    type: str
+    choices: [ cloudfoundry, kubernetes, microsoft, openshift, openstack, redhat, vmware ]
+extends_documentation_fragment:
+- cisco.aci.aci
+
+seealso:
+- module: cisco.aci.aci_domain
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(vmm:DomP)
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Manuel Widmer (@lumean)
+'''
+
+EXAMPLES = r'''
+- name: Add a vSwitch policy with LLDP
+  cisco.aci.aci_vmm_vswitch:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    lldp_policy: LLDP_ENABLED
+    domain: vmware_dom
+    vm_provider: vmware
+    state: present
+
+- name: Add a vSwitch policy with link aggregation
+  cisco.aci.aci_vmm_vswitch:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_channel_policy: LACP_ACTIVE
+    lldp_policy: LLDP_ENABLED
+    domain: vmware_dom
+    vm_provider: vmware
+    enhanced_lag:
+      - name: my_lacp_uplink
+        lacp_mode: active
+        load_balancing_mode: src-dst-ip
+        number_uplinks: 2
+    state: present
+
+- name: Remove vSwitch Policy from VMware VMM domain
+  cisco.aci.aci_vmm_vswitch:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    domain: vmware_dom
+    vm_provider: vmware
+    state: absent
+
+- name: Query the vSwitch policy of the VMWare domain
+  cisco.aci.aci_vmm_vswitch:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    domain: vmware_dom
+    vm_provider: vmware
+    state: query
+  delegate_to: localhost
+  register: query_result
+'''
+
+RETURN = r'''
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
+
+# via UI vSwitch Policy can only be added for VMware and Microsoft vmm domains
+# behavior for other domains is currently untested.
+VM_PROVIDER_MAPPING = dict(
+    cloudfoundry='CloudFoundry',
+    kubernetes='Kubernetes',
+    microsoft='Microsoft',
+    openshift='OpenShift',
+    openstack='OpenStack',
+    redhat='Redhat',
+    vmware='VMware',
+)
+
+enhanced_lag_spec = dict(
+    name=dict(type='str', required=True),
+    lacp_mode=dict(type='str', choices=['active', 'passive']),
+    load_balancing_mode=dict(
+        type='str',
+        choices=['dst-ip', 'dst-ip-l4port', 'dst-ip-vlan', 'dst-ip-l4port-vlan', 'dst-mac', 'dst-l4port',
+                 'src-ip', 'src-ip-l4port', 'src-ip-vlan', 'src-ip-l4port-vlan', 'src-mac', 'src-l4port',
+                 'src-dst-ip', 'src-dst-ip-l4port', 'src-dst-ip-vlan', 'src-dst-ip-l4port-vlan', 'src-dst-mac',
+                 'src-dst-l4port', 'src-port-id', 'vlan']),
+    number_uplinks=dict(type='int'),
+)
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(
+        port_channel_policy=dict(type='str'),
+        lldp_policy=dict(type='str'),
+        cdp_policy=dict(type='str'),
+        mtu_policy=dict(type='str'),
+        enhanced_lag=dict(type='list', elements='dict', options=enhanced_lag_spec),
+        domain=dict(type='str', required=True, aliases=['domain_name', 'domain_profile']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+        vm_provider=dict(type='str', choices=list(VM_PROVIDER_MAPPING.keys())),
+        name_alias=dict(type='str'),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'absent', ['domain']],
+            ['state', 'present', ['domain']],
+        ],
+    )
+
+    port_channel_policy = module.params.get('port_channel_policy')
+    lldp_policy = module.params.get('lldp_policy')
+    cdp_policy = module.params.get('cdp_policy')
+    mtu_policy = module.params.get('mtu_policy')
+    enhanced_lag = module.params.get('enhanced_lag')
+    domain = module.params.get('domain')
+    state = module.params.get('state')
+    vm_provider = module.params.get('vm_provider')
+    name_alias = module.params.get('name_alias')
+
+    vswitch_class = 'vmmVSwitchPolicyCont'
+    vswitch_container_mo = 'uni/vmmp-{0}/dom-{1}/vswitchpolcont'.format(VM_PROVIDER_MAPPING.get(vm_provider), domain)
+    vswitch_container_rn = 'vmmp-{0}/dom-{1}/vswitchpolcont'.format(VM_PROVIDER_MAPPING.get(vm_provider), domain)
+
+    # Ensure that querying all objects works when only domain is provided
+    # if name is None:
+    #    vswitch_container_mo = None
+
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class=dict(
+            aci_class=vswitch_class,
+            aci_rn=vswitch_container_rn,
+            module_object=vswitch_container_mo,
+            target_filter=None
+            # target_filter={'name': domain, 'usracc': name},
+        ),
+        child_classes=[
+            'vmmRsVswitchOverrideMtuPol',
+            'vmmRsVswitchOverrideLldpIfPol',
+            'vmmRsVswitchOverrideLacpPol',
+            'vmmRsVswitchOverrideCdpIfPol',
+            'lacpEnhancedLagPol'
+        ]
+    )
+
+    aci.get_existing()
+
+    if state == 'present':
+        children = list()
+
+        if port_channel_policy is not None:
+            children.append(dict(vmmRsVswitchOverrideLacpPol=dict(attributes=dict(
+                tDn='uni/infra/lacplagp-{0}'.format(port_channel_policy)
+            ))))
+
+        if lldp_policy is not None:
+            children.append(dict(vmmRsVswitchOverrideLldpIfPol=dict(attributes=dict(
+                tDn='uni/infra/lldpIfP-{0}'.format(lldp_policy)
+            ))))
+
+        if cdp_policy is not None:
+            children.append(dict(vmmRsVswitchOverrideCdpIfPol=dict(attributes=dict(
+                tDn='uni/infra/cdpIfP-{0}'.format(cdp_policy)
+            ))))
+
+        if mtu_policy is not None:
+            children.append(dict(vmmRsVswitchOverrideMtuPol=dict(attributes=dict(
+                tDn='uni/fabric/l2pol-{0}'.format(mtu_policy)
+            ))))
+
+        if isinstance(enhanced_lag, list):
+            for lag_dict in enhanced_lag:
+                children.append(dict(lacpEnhancedLagPol=dict(attributes=dict(
+                    name=lag_dict['name'],
+                    mode=lag_dict['lacp_mode'],
+                    lbmode=lag_dict['load_balancing_mode'],
+                    numLinks=lag_dict['number_uplinks'],
+                ))))
+
+        aci.payload(
+            aci_class=vswitch_class,
+            class_config=dict(
+                nameAlias=name_alias,
+            ),
+            child_configs=children
+        )
+
+        aci.get_diff(aci_class=vswitch_class)
+
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aci_vmm_vswitch_policy.py
+++ b/plugins/modules/aci_vmm_vswitch_policy.py
@@ -41,7 +41,6 @@ options:
     - Name of the virtual domain profile.
     type: str
     aliases: [ domain_name, domain_profile ]
-    required: true
   enhanced_lag:
     description:
     - List of enhanced LAG policies if vSwitch needs to be connected via VPC.
@@ -387,25 +386,25 @@ def main():
         child_classes.append('vmmRsVswitchExporterPol')
 
     aci.construct_url(
-      root_class=dict(
-          aci_class='vmmProvP',
-          aci_rn='vmmp-{0}'.format(VM_PROVIDER_MAPPING.get(vm_provider)),
-          module_object=vm_provider,
-          target_filter={'name': vm_provider},
-      ),
-      subclass_1=dict(
-          aci_class='vmmDomP',
-          aci_rn='dom-{0}'.format(domain),
-          module_object=domain,
-          target_filter={'name': domain},
-      ),
-      subclass_2=dict(
-          aci_class='vmmVSwitchPolicyCont',
-          aci_rn='vswitchpolcont',
-          module_object='vswitchpolcont',
-          target_filter={'name': 'vswitchpolcont'},
-      ),
-      child_classes=child_classes,
+        root_class=dict(
+            aci_class='vmmProvP',
+            aci_rn='vmmp-{0}'.format(VM_PROVIDER_MAPPING.get(vm_provider)),
+            module_object=vm_provider,
+            target_filter={'name': vm_provider},
+        ),
+        subclass_1=dict(
+            aci_class='vmmDomP',
+            aci_rn='dom-{0}'.format(domain),
+            module_object=domain,
+            target_filter={'name': domain},
+        ),
+        subclass_2=dict(
+            aci_class='vmmVSwitchPolicyCont',
+            aci_rn='vswitchpolcont',
+            module_object='vswitchpolcont',
+            target_filter={'name': 'vswitchpolcont'},
+        ),
+        child_classes=child_classes,
     )
 
     aci.get_existing()

--- a/plugins/modules/aci_vmm_vswitch_policy.py
+++ b/plugins/modules/aci_vmm_vswitch_policy.py
@@ -15,9 +15,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_vmm_vswitch_policy
-short_description: Manage vSwitch policy for VmWare virtual domains profiles (vmm:DomP)
+short_description: Manage vSwitch policy for VMware virtual domains profiles (vmm:DomP)
 description:
-- Manage vSwitch policy for VmWare vmm domains on Cisco ACI fabrics.
+- Manage vSwitch policy for VMware VMM domains on Cisco ACI fabrics.
 options:
   port_channel_policy:
     description:
@@ -60,7 +60,7 @@ options:
       load_balancing_mode:
         description:
         - Load balancing mode of the port channel.
-        - See also https://pubhub.devnetcloud.com/media/apic-mim-ref-421/docs/MO-lacpEnhancedLagPol.html .
+        - See also https://pubhub.devnetcloud.com/media/apic-mim-ref-421/docs/MO-lacpEnhancedLagPol.html.
         type: str
         choices:
           - dst-ip
@@ -142,6 +142,7 @@ seealso:
   link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Manuel Widmer (@lumean)
+- Anvitha Jain (@anvitha-jain)
 '''
 
 EXAMPLES = r'''
@@ -298,7 +299,7 @@ url:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, enhanced_lag_spec, netflow_spec
 
 # via UI vSwitch Policy can only be added for VMware and Microsoft vmm domains
 # behavior for other domains is currently untested.
@@ -312,24 +313,24 @@ VM_PROVIDER_MAPPING = dict(
     vmware='VMware',
 )
 
-enhanced_lag_spec = dict(
-    name=dict(type='str', required=True),
-    lacp_mode=dict(type='str', choices=['active', 'passive']),
-    load_balancing_mode=dict(
-        type='str',
-        choices=['dst-ip', 'dst-ip-l4port', 'dst-ip-vlan', 'dst-ip-l4port-vlan', 'dst-mac', 'dst-l4port',
-                 'src-ip', 'src-ip-l4port', 'src-ip-vlan', 'src-ip-l4port-vlan', 'src-mac', 'src-l4port',
-                 'src-dst-ip', 'src-dst-ip-l4port', 'src-dst-ip-vlan', 'src-dst-ip-l4port-vlan', 'src-dst-mac',
-                 'src-dst-l4port', 'src-port-id', 'vlan']),
-    number_uplinks=dict(type='int'),
-)
+# enhanced_lag_spec = dict(
+#     name=dict(type='str', required=True),
+#     lacp_mode=dict(type='str', choices=['active', 'passive']),
+#     load_balancing_mode=dict(
+#         type='str',
+#         choices=['dst-ip', 'dst-ip-l4port', 'dst-ip-vlan', 'dst-ip-l4port-vlan', 'dst-mac', 'dst-l4port',
+#                  'src-ip', 'src-ip-l4port', 'src-ip-vlan', 'src-ip-l4port-vlan', 'src-mac', 'src-l4port',
+#                  'src-dst-ip', 'src-dst-ip-l4port', 'src-dst-ip-vlan', 'src-dst-ip-l4port-vlan', 'src-dst-mac',
+#                  'src-dst-l4port', 'src-port-id', 'vlan']),
+#     number_uplinks=dict(type='int'),
+# )
 
-netflow_spec = dict(
-    name=dict(type='str', required=True),
-    active_flow_timeout=dict(type='int'),
-    idle_flow_timeout=dict(type='int'),
-    sampling_rate=dict(type='int'),
-)
+# netflow_spec = dict(
+#     name=dict(type='str', required=True),
+#     active_flow_timeout=dict(type='int'),
+#     idle_flow_timeout=dict(type='int'),
+#     sampling_rate=dict(type='int'),
+# )
 
 
 def main():
@@ -340,8 +341,8 @@ def main():
         cdp_policy=dict(type='str'),
         mtu_policy=dict(type='str'),
         stp_policy=dict(type='str'),
-        enhanced_lag=dict(type='list', elements='dict', options=enhanced_lag_spec),
-        netflow_exporter=dict(type='dict', options=netflow_spec),
+        enhanced_lag=dict(type='list', elements='dict', options=enhanced_lag_spec()),
+        netflow_exporter=dict(type='dict', options=netflow_spec()),
         domain=dict(type='str', aliases=['domain_name', 'domain_profile']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         vm_provider=dict(type='str', choices=list(VM_PROVIDER_MAPPING.keys())),

--- a/tests/integration/targets/aci_vmm_vswitch_policy/aliases
+++ b/tests/integration/targets/aci_vmm_vswitch_policy/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_vmm_vswitch_policy/tasks/main.yml
+++ b/tests/integration/targets/aci_vmm_vswitch_policy/tasks/main.yml
@@ -15,18 +15,26 @@
       use_proxy: '{{ aci_use_proxy | default(true) }}'
       output_level: '{{ aci_output_level | default("debug") }}'
 
+- name: Query system information
+  aci_system:
+    <<: *aci_info
+    id: 1
+    state: query
+  register: version
+
 # Remove VMM domain
 - name: Remove VMM domain (normal mode)
   cisco.aci.aci_domain:
     <<: *aci_info
-    domain: vmm_dom
+    domain: '{{ item.domain }}'
     domain_type: vmm
-    vm_provider: "{{ item }}"
+    vm_provider: '{{ item.provider }}'
     state: absent
   register: nm_remove_domain
   loop:
-    - vmware
-    - microsoft
+    - { domain: 'vmm_dom', provider: 'vmware' }
+    - { domain: 'vmm_dom', provider: 'microsoft' }
+    - { domain: 'microsoft_dom', provider: 'microsoft' }
 
 - name: Verify Cloud and Non-Cloud Sites in use.
   include_tasks: ../../../../../../integration/targets/aci_cloud_provider/tasks/main.yml
@@ -38,14 +46,15 @@
   - name: Add VMM domain
     cisco.aci.aci_domain:
       <<: *aci_info
-      domain: vmm_dom
+      domain: '{{ item.domain }}'
       domain_type: vmm
-      vm_provider: "{{ item }}"
+      vm_provider: '{{ item.provider }}'
       state: present
     register: nm_add_domain
     loop:
-      - vmware
-      - microsoft
+      - { domain: 'vmm_dom', provider: 'vmware' }
+      - { domain: 'vmm_dom', provider: 'microsoft' }
+      - { domain: 'microsoft_dom', provider: 'microsoft' }
 
   - name: Verify VMM add_domain
     assert:
@@ -53,7 +62,7 @@
       - nm_add_domain is changed
 
   - name: Add a vSwitch policy to vmware domain
-    aci_vmm_vswitch_policy:
+    aci_vmm_vswitch_policy: &add_vmware_policies
       <<: *aci_info
       domain: vmm_dom
       vm_provider: vmware
@@ -72,6 +81,43 @@
       - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-PORT_Channel_policy'
       - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-CDP_policy'
       - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-LLDP_policy'
+
+  - name: Add a vSwitch policy to vmware domain
+    aci_vmm_vswitch_policy:
+      <<: *add_vmware_policies
+      netflow_exporter:
+        name: Netflow_Exporter_policy
+      enhanced_lag:
+      - name: Enhanced_Lag_pol
+      state: present
+    register: add_vmware_policy_2
+
+  - name: Verify VMM add_vmware_policy_2
+    assert:
+      that:
+      - add_vmware_policy_2 is changed
+      - add_vmware_policy_2.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
+      - add_vmware_policy_2.current.0.vmmVSwitchPolicyCont.children.0.lacpEnhancedLagPol.attributes.name == 'Enhanced_Lag_pol'
+      - add_vmware_policy_2.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchExporterPol.attributes.tDn == 'uni/infra/vmmexporterpol-Netflow_Exporter_policy'
+      - add_vmware_policy_2.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-PORT_Channel_policy'
+      - add_vmware_policy_2.current.0.vmmVSwitchPolicyCont.children.3.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-CDP_policy'
+      - add_vmware_policy_2.current.0.vmmVSwitchPolicyCont.children.4.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-LLDP_policy'
+
+  - name: Add MTU policy to vmware domain when version is >= 4.2
+    aci_vmm_vswitch_policy:
+      <<: *add_vmware_policies
+      mtu_policy: MTU_policy
+      state: present
+    register: add_vmware_mtu_policy
+    when: version.current.0.topSystem.attributes.version is version('4.2', '>=')
+
+  - name: Verify VMM add_vmware_mtu_policy
+    assert:
+      that:
+      - add_vmware_mtu_policy is changed
+      - add_vmware_mtu_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
+      - add_vmware_mtu_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideMtuPol.attributes.tDn == 'uni/fabric/l2pol-MTU_policy'
+    when: version.current.0.topSystem.attributes.version is version('4.2', '>=')
 
   - name: Add a vSwitch policy to microsoft domain
     aci_vmm_vswitch_policy:
@@ -93,6 +139,23 @@
       - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-ms_PORT_Channel_policy'
       - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-ms_CDP_policy'
       - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-ms_LLDP_policy'
+
+  - name: Add STP vSwitch policy to another microsoft domain
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      domain: microsoft_dom
+      vm_provider: microsoft
+      stp_policy: ms_STP_policy
+      state: present
+    register: add_microsoft_stp_policy
+
+  - name: Verify VMM add_microsoft_stp_policy
+    assert:
+      that:
+      - add_microsoft_stp_policy is changed
+      - add_microsoft_stp_policy.previous == []
+      - add_microsoft_stp_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-Microsoft/dom-microsoft_dom/vswitchpolcont'
+      - add_microsoft_stp_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideStpPol.attributes.tDn == 'uni/infra/ifPol-ms_STP_policy'
 
   - name: Query all the vSwitch policy
     aci_vmm_vswitch_policy:

--- a/tests/integration/targets/aci_vmm_vswitch_policy/tasks/main.yml
+++ b/tests/integration/targets/aci_vmm_vswitch_policy/tasks/main.yml
@@ -28,108 +28,114 @@
     - vmware
     - microsoft
 
-# ADD DOMAIN
-- name: Add VMM domain
-  cisco.aci.aci_domain:
-    <<: *aci_info
-    domain: vmm_dom
-    domain_type: vmm
-    vm_provider: "{{ item }}"
-    state: present
-  register: nm_add_domain
-  loop:
-    - vmware
-    - microsoft
+- name: Verify Cloud and Non-Cloud Sites in use.
+  include_tasks: ../../../../../../integration/targets/aci_cloud_provider/tasks/main.yml
 
-- name: Verify VMM add_domain
-  assert:
-    that:
-    - nm_add_domain is changed
+- name: Execute tasks only for non-cloud sites
+  when: query_cloud.current == []  # This condition will skip execution for cloud sites
+  block:
+  # ADD DOMAIN
+  - name: Add VMM domain
+    cisco.aci.aci_domain:
+      <<: *aci_info
+      domain: vmm_dom
+      domain_type: vmm
+      vm_provider: "{{ item }}"
+      state: present
+    register: nm_add_domain
+    loop:
+      - vmware
+      - microsoft
 
-- name: Add a vSwitch policy to vmware domain
-  aci_vmm_vswitch_policy:
-    <<: *aci_info
-    domain: vmm_dom
-    vm_provider: vmware
-    lldp_policy: LLDP_policy
-    cdp_policy: CDP_policy
-    port_channel_policy: PORT_Channel_policy
-    state: present
-  register: add_vmware_policy
+  - name: Verify VMM add_domain
+    assert:
+      that:
+      - nm_add_domain is changed
 
-- name: Verify VMM add_vmware_policy
-  assert:
-    that:
-    - add_vmware_policy is changed
-    - add_vmware_policy.previous == []
-    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
-    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-PORT_Channel_policy'
-    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-CDP_policy'
-    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-LLDP_policy'
+  - name: Add a vSwitch policy to vmware domain
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      domain: vmm_dom
+      vm_provider: vmware
+      lldp_policy: LLDP_policy
+      cdp_policy: CDP_policy
+      port_channel_policy: PORT_Channel_policy
+      state: present
+    register: add_vmware_policy
 
-- name: Add a vSwitch policy to microsoft domain
-  aci_vmm_vswitch_policy:
-    <<: *aci_info
-    domain: vmm_dom
-    vm_provider: microsoft
-    lldp_policy: ms_LLDP_policy
-    cdp_policy: ms_CDP_policy
-    port_channel_policy: ms_PORT_Channel_policy
-    state: present
-  register: add_microsoft_policy
+  - name: Verify VMM add_vmware_policy
+    assert:
+      that:
+      - add_vmware_policy is changed
+      - add_vmware_policy.previous == []
+      - add_vmware_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
+      - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-PORT_Channel_policy'
+      - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-CDP_policy'
+      - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-LLDP_policy'
 
-- name: Verify VMM add_microsoft_policy
-  assert:
-    that:
-    - add_microsoft_policy is changed
-    - add_microsoft_policy.previous == []
-    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-Microsoft/dom-vmm_dom/vswitchpolcont'
-    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-ms_PORT_Channel_policy'
-    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-ms_CDP_policy'
-    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-ms_LLDP_policy'
+  - name: Add a vSwitch policy to microsoft domain
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      domain: vmm_dom
+      vm_provider: microsoft
+      lldp_policy: ms_LLDP_policy
+      cdp_policy: ms_CDP_policy
+      port_channel_policy: ms_PORT_Channel_policy
+      state: present
+    register: add_microsoft_policy
 
-- name: Query all the vSwitch policy
-  aci_vmm_vswitch_policy:
-    <<: *aci_info
-    state: query
-  register: query_all_vmware
+  - name: Verify VMM add_microsoft_policy
+    assert:
+      that:
+      - add_microsoft_policy is changed
+      - add_microsoft_policy.previous == []
+      - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-Microsoft/dom-vmm_dom/vswitchpolcont'
+      - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-ms_PORT_Channel_policy'
+      - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-ms_CDP_policy'
+      - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-ms_LLDP_policy'
 
-- name: Query all the vSwitch policy of the VMWare domain
-  aci_vmm_vswitch_policy:
-    <<: *aci_info
-    state: query
-  register: query_all_microsoft
+  - name: Query all the vSwitch policy
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      state: query
+    register: query_all_vmware
 
-- name: Verify Query all tasks for vmware and microsoft domain
-  assert:
-    that:
-    - query_all_vmware is not changed
-    - query_all_microsoft is not changed
+  - name: Query all the vSwitch policy of the VMWare domain
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      state: query
+    register: query_all_microsoft
 
-- name: Query vSwitch policies of VMWare domain
-  aci_vmm_vswitch_policy:
-    <<: *aci_info
-    domain: vmm_dom
-    vm_provider: vmware
-    state: query
-  register: query_vmware
+  - name: Verify Query all tasks for vmware and microsoft domain
+    assert:
+      that:
+      - query_all_vmware is not changed
+      - query_all_microsoft is not changed
 
-- name: Verify Query vSwitch policy of the VMWare domain
-  assert:
-    that:
-    - query_vmware is not changed
-    - query_vmware.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
+  - name: Query vSwitch policies of VMWare domain
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      domain: vmm_dom
+      vm_provider: vmware
+      state: query
+    register: query_vmware
 
-- name: Remove vSwitch Policy from VMware VMM domain
-  aci_vmm_vswitch_policy:
-    <<: *aci_info
-    domain: vmm_dom
-    vm_provider: vmware
-    state: absent
-  register: remove_vmware_vSwitch_policy
+  - name: Verify Query vSwitch policy of the VMWare domain
+    assert:
+      that:
+      - query_vmware is not changed
+      - query_vmware.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
 
-- name: Verify remove_vmware_vSwitch_policy
-  assert:
-    that:
-    - remove_vmware_vSwitch_policy is changed
-    - remove_vmware_vSwitch_policy.current == []
+  - name: Remove vSwitch Policy from VMware VMM domain
+    aci_vmm_vswitch_policy:
+      <<: *aci_info
+      domain: vmm_dom
+      vm_provider: vmware
+      state: absent
+    register: remove_vmware_vSwitch_policy
+
+  - name: Verify remove_vmware_vSwitch_policy
+    assert:
+      that:
+      - remove_vmware_vSwitch_policy is changed
+      - remove_vmware_vSwitch_policy.current == []

--- a/tests/integration/targets/aci_vmm_vswitch_policy/tasks/main.yml
+++ b/tests/integration/targets/aci_vmm_vswitch_policy/tasks/main.yml
@@ -1,0 +1,135 @@
+# Test code for the ACI modules
+# Copyright: (c) 2021, Anvitha Jain (@anvitha-jain) <anvjain@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# CLEAN ENVIRONMENT
+- name: Set vars
+  set_fact:
+    aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: '{{ aci_output_level | default("debug") }}'
+
+# Remove VMM domain
+- name: Remove VMM domain (normal mode)
+  cisco.aci.aci_domain:
+    <<: *aci_info
+    domain: vmm_dom
+    domain_type: vmm
+    vm_provider: "{{ item }}"
+    state: absent
+  register: nm_remove_domain
+  loop:
+    - vmware
+    - microsoft
+
+# ADD DOMAIN
+- name: Add VMM domain
+  cisco.aci.aci_domain:
+    <<: *aci_info
+    domain: vmm_dom
+    domain_type: vmm
+    vm_provider: "{{ item }}"
+    state: present
+  register: nm_add_domain
+  loop:
+    - vmware
+    - microsoft
+
+- name: Verify VMM add_domain
+  assert:
+    that:
+    - nm_add_domain is changed
+
+- name: Add a vSwitch policy to vmware domain
+  aci_vmm_vswitch_policy:
+    <<: *aci_info
+    domain: vmm_dom
+    vm_provider: vmware
+    lldp_policy: LLDP_policy
+    cdp_policy: CDP_policy
+    port_channel_policy: PORT_Channel_policy
+    state: present
+  register: add_vmware_policy
+
+- name: Verify VMM add_vmware_policy
+  assert:
+    that:
+    - add_vmware_policy is changed
+    - add_vmware_policy.previous == []
+    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
+    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-PORT_Channel_policy'
+    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-CDP_policy'
+    - add_vmware_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-LLDP_policy'
+
+- name: Add a vSwitch policy to microsoft domain
+  aci_vmm_vswitch_policy:
+    <<: *aci_info
+    domain: vmm_dom
+    vm_provider: microsoft
+    lldp_policy: ms_LLDP_policy
+    cdp_policy: ms_CDP_policy
+    port_channel_policy: ms_PORT_Channel_policy
+    state: present
+  register: add_microsoft_policy
+
+- name: Verify VMM add_microsoft_policy
+  assert:
+    that:
+    - add_microsoft_policy is changed
+    - add_microsoft_policy.previous == []
+    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-Microsoft/dom-vmm_dom/vswitchpolcont'
+    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.0.vmmRsVswitchOverrideLacpPol.attributes.tDn == 'uni/infra/lacplagp-ms_PORT_Channel_policy'
+    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.1.vmmRsVswitchOverrideCdpIfPol.attributes.tDn == 'uni/infra/cdpIfP-ms_CDP_policy'
+    - add_microsoft_policy.current.0.vmmVSwitchPolicyCont.children.2.vmmRsVswitchOverrideLldpIfPol.attributes.tDn == 'uni/infra/lldpIfP-ms_LLDP_policy'
+
+- name: Query all the vSwitch policy
+  aci_vmm_vswitch_policy:
+    <<: *aci_info
+    state: query
+  register: query_all_vmware
+
+- name: Query all the vSwitch policy of the VMWare domain
+  aci_vmm_vswitch_policy:
+    <<: *aci_info
+    state: query
+  register: query_all_microsoft
+
+- name: Verify Query all tasks for vmware and microsoft domain
+  assert:
+    that:
+    - query_all_vmware is not changed
+    - query_all_microsoft is not changed
+
+- name: Query vSwitch policies of VMWare domain
+  aci_vmm_vswitch_policy:
+    <<: *aci_info
+    domain: vmm_dom
+    vm_provider: vmware
+    state: query
+  register: query_vmware
+
+- name: Verify Query vSwitch policy of the VMWare domain
+  assert:
+    that:
+    - query_vmware is not changed
+    - query_vmware.current.0.vmmVSwitchPolicyCont.attributes.dn == 'uni/vmmp-VMware/dom-vmm_dom/vswitchpolcont'
+
+- name: Remove vSwitch Policy from VMware VMM domain
+  aci_vmm_vswitch_policy:
+    <<: *aci_info
+    domain: vmm_dom
+    vm_provider: vmware
+    state: absent
+  register: remove_vmware_vSwitch_policy
+
+- name: Verify remove_vmware_vSwitch_policy
+  assert:
+    that:
+    - remove_vmware_vSwitch_policy is changed
+    - remove_vmware_vSwitch_policy.current == []


### PR DESCRIPTION
This module adds support for vswitch policies on VMM domains including enhanced LAG for VMWare. It addresses another part of the functionality needed for #29 

I'm not sure if we should keep all possible `vm_providers`, as per ACI UI I could only test the creation of vswitch policy for Microsoft SCVMM and VMWare  domains. Otherwise I'm also happy to remove the other `vm_providers` and eventually only add them back if we are sure the capabilites exist.