### PR TITLE
Add new module aci_l2out_extepg_to_contract

### DIFF
--- a/plugins/modules/aci_l2out_extepg_to_contract.py
+++ b/plugins/modules/aci_l2out_extepg_to_contract.py
@@ -1,0 +1,348 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Sudhakar Shet Kudtarkar (@kudtarkar1)
+# Copyright: (c) 2020, Shreyas Srish <ssrish@cisco.com>
+# Copyright: (c) 2021, Oleksandr Kreshchenko (@alexkross)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_l2out_extepg_to_contract
+short_description: Bind Contracts to L2 External End Point Groups (EPGs)
+description:
+- Bind Contracts to L2 External End Point Groups (EPGs) on ACI fabrics.
+options:
+  tenant:
+    description:
+    - Name of existing tenant.
+    type: str
+  l2out:
+    description:
+    - Name of the l2out.
+    type: str
+    aliases: ['l2out_name']
+  extepg:
+    description:
+    - Name of the external end point group.
+    type: str
+    aliases: ['extepg_name', 'external_epg']
+  contract:
+    description:
+    - Name of the contract.
+    type: str
+  contract_type:
+    description:
+    - The type of contract.
+    type: str
+    required: yes
+    choices: ['consumer', 'provider']
+  priority:
+    description:
+    - This has four levels of priority.
+    type: str
+    choices: ['level1', 'level2', 'level3', 'unspecified']
+  provider_match:
+    description:
+    - This is configurable for provided contracts.
+    type: str
+    choices: ['all', 'at_least_one', 'at_most_one', 'none']
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment:
+- cisco.aci.aci
+
+notes:
+- The C(tenant), C(l2out) and C(extepg) must exist before using this module in your playbook.
+  The M(cisco.aci.aci_tenant), M(cisco.aci.aci_l2out) and M(cisco.aci.aci_l2out_extepg) modules can be used for this.
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fvtenant), B(l2extInstP) and B(l2extOut).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Sudhakar Shet Kudtarkar (@kudtarkar1)
+- Shreyas Srish (@shrsr)
+- Oleksandr Kreshchenko (@alexkross)
+'''
+
+EXAMPLES = r'''
+- name: Bind a contract to an L2 external EPG
+  cisco.aci.aci_l2out_extepg_to_contract:
+    host: apic
+    username: admin
+    password: SomeSecretePassword
+    tenant: Auto-Demo
+    l2out: l2out
+    extepg : testEpg
+    contract: contract1
+    contract_type: provider
+    state: present
+  delegate_to: localhost
+
+- name: Remove existing contract from an L2 external EPG
+  cisco.aco.aci_l2out_extepg_to_contract:
+    host: apic
+    username: admin
+    password: SomeSecretePassword
+    tenant: Auto-Demo
+    l2out: l2out
+    extepg : testEpg
+    contract: contract1
+    contract_type: provider
+    state: absent
+  delegate_to: localhost
+
+- name: Query a contract bound to an L2 external EPG
+  cisco.aci.aci_l2out_extepg_to_contract:
+    host: apic
+    username: admin
+    password: SomeSecretePassword
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extEpg
+    contract: ansible_contract
+    contract_type: provider
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all contracts relationships
+  cisco.aci.aci_l2out_extepg_to_contract:
+    host: apic
+    username: admin
+    password: SomeSecretePassword
+    contract_type: provider
+    state: query
+  delegate_to: localhost
+  register: query_result
+'''
+
+RETURN = r'''
+   current:
+     description: The existing configuration from the APIC after the module has finished
+     returned: success
+     type: list
+     sample:
+       [
+           {
+               "fvTenant": {
+                   "attributes": {
+                       "descr": "Production environment",
+                       "dn": "uni/tn-production",
+                       "name": "production",
+                       "nameAlias": "",
+                       "ownerKey": "",
+                       "ownerTag": ""
+                   }
+               }
+           }
+       ]
+   error:
+     description: The error information as returned from the APIC
+     returned: failure
+     type: dict
+     sample:
+       {
+           "code": "122",
+           "text": "unknown managed object class foo"
+       }
+   raw:
+     description: The raw output returned by the APIC REST API (xml or json)
+     returned: parse error
+     type: str
+     sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class "/></imdata>'
+   sent:
+     description: The actual/minimal configuration pushed to the APIC
+     returned: info
+     type: list
+     sample:
+       {
+           "fvTenant": {
+               "attributes": {
+                   "descr": "Production environment"
+               }
+           }
+       }
+   previous:
+     description: The original configuration from the APIC before the module has started
+     returned: info
+     type: list
+     sample:
+       [
+           {
+               "fvTenant": {
+                   "attributes": {
+                       "descr": "Production",
+                       "dn": "uni/tn-production",
+                       "name": "production",
+                       "nameAlias": "",
+                       "ownerKey": "",
+                       "ownerTag": ""
+                   }
+               }
+           }
+       ]
+   proposed:
+     description: The assembled configuration from the user-provided parameters
+     returned: info
+     type: dict
+     sample:
+       {
+           "fvTenant": {
+               "attributes": {
+                   "descr": "Production environment",
+                   "name": "production"
+               }
+           }
+       }
+   filter_string:
+     description: The filter string used for the request
+     returned: failure or debug
+     type: str
+     sample: ?rsp-prop-include=config-only
+   method:
+     description: The HTTP method used for the request to the APIC
+     returned: failure or debug
+     type: str
+     sample: POST
+   response:
+     description: The HTTP response from the APIC
+     returned: failure or debug
+     type: str
+     sample: OK (30 bytes)
+   status:
+     description: The HTTP status from the APIC
+     returned: failure or debug
+     type: int
+     sample: 200
+   url:
+     description: The HTTP url used for the request to the APIC
+     returned: failure or debug
+     type: str
+     sample: https://10.11.12.13/api/mo/uni/tn-production.json
+   '''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
+
+ACI_CLASS_MAPPING = dict(
+    consumer={
+        'class': 'fvRsCons',
+        'rn': 'rscons-',
+    },
+    provider={
+        'class': 'fvRsProv',
+        'rn': 'rsprov-',
+    },
+)
+
+PROVIDER_MATCH_MAPPING = dict(
+    all='All',
+    at_least_one='AtleastOne',
+    at_most_one='tmostOne',
+    none='None',
+)
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(
+        contract_type=dict(type='str', required=True, choices=['consumer', 'provider']),
+        l2out=dict(type='str', aliases=['l2out_name']),
+        contract=dict(type='str'),
+        priority=dict(type='str', choices=['level1', 'level2', 'level3', 'unspecified']),
+        provider_match=dict(type='str', choices=['all', 'at_least_one', 'at_most_one', 'none']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+        tenant=dict(type='str'),
+        extepg=dict(type='str', aliases=['extepg_name', 'external_epg']),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'absent', ['extepg', 'contract', 'l2out', 'tenant']],
+            ['state', 'present', ['extepg', 'contract', 'l2out', 'tenant']],
+        ],
+    )
+
+    l2out = module.params.get('l2out')
+    contract = module.params.get('contract')
+    contract_type = module.params.get('contract_type')
+    extepg = module.params.get('extepg')
+    priority = module.params.get('priority')
+    provider_match = module.params.get('provider_match')
+    if provider_match is not None:
+        provider_match = PROVIDER_MATCH_MAPPING.get(provider_match)
+    state = module.params.get('state')
+    tenant = module.params.get('tenant')
+
+    aci_class = ACI_CLASS_MAPPING.get(contract_type)["class"]
+    aci_rn = ACI_CLASS_MAPPING.get(contract_type)["rn"]
+
+    if contract_type == "consumer" and provider_match is not None:
+        module.fail_json(msg="the 'provider_match' is only configurable for Provided Contracts")
+
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class=dict(
+            aci_class='fvTenant',
+            aci_rn='tn-{0}'.format(tenant),
+            module_object=tenant,
+            target_filter={'name': tenant},
+        ),
+        subclass_1=dict(
+            aci_class='l2extOut',
+            aci_rn='l2out-{0}'.format(l2out),
+            module_object=l2out,
+            target_filter={'name': l2out},
+        ),
+        subclass_2=dict(
+            aci_class='l2extInstP',
+            aci_rn='instP-{0}'.format(extepg),
+            module_object=extepg,
+            target_filter={'name': extepg},
+        ),
+        subclass_3=dict(
+            aci_class=aci_class,
+            aci_rn='{0}{1}'.format(aci_rn, contract),
+            module_object=contract,
+            target_filter={'tnVzBrCPName': contract},
+        ),
+    )
+
+    aci.get_existing()
+
+    if state == 'present':
+        aci.payload(
+            aci_class=aci_class,
+            class_config=dict(
+                matchT=provider_match,
+                prio=priority,
+                tnVzBrCPName=contract,
+            ),
+        )
+
+        aci.get_diff(aci_class=aci_class)
+
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aci_l2out_extepg_to_contract/aliases
+++ b/tests/integration/targets/aci_l2out_extepg_to_contract/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_l2out_extepg_to_contract/tasks/main.yml
+++ b/tests/integration/targets/aci_l2out_extepg_to_contract/tasks/main.yml
@@ -1,0 +1,198 @@
+# Test code for the ACI modules
+# Copyright: (c) 2021, Anvitha Jain (@anvitha-jain) <anvjain@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  set_fact: 
+   aci_info: &aci_info
+    host: "{{ aci_hostname }}"
+    username: "{{ aci_username }}"
+    password: "{{ aci_password }}"
+    validate_certs: '{{ aci_validate_certs | default(false) }}'
+    use_ssl: '{{ aci_use_ssl | default(true) }}'
+    use_proxy: '{{ aci_use_proxy | default(true) }}'
+    output_level: debug
+
+# CLEAN ENVIRONMENT
+- name: Remove the ansible_tenant
+  aci_tenant:
+    <<: *aci_info
+    tenant: ansible_tenant
+    state: absent
+
+- name: Add a new tenant
+  aci_tenant:
+    <<: *aci_info
+    tenant: ansible_tenant
+    description: Ansible tenant
+    state: present
+
+- name: Add New L2Out
+  aci_l2out:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    description: Ansible Test
+    bd: ansible_bd
+    domain: l2Dom
+    vlan: 3200
+    state: present
+  register: add_l2out
+
+- name: Add another L2Out
+  aci_l2out:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out_2
+    description: Ansible Test
+    bd: ansible_bd
+    domain: l2Dom
+    vlan: 3200
+    state: present
+  register: add_l2out_2
+
+- name: Add L2 external end point group
+  aci_l2out_extepg:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extepg
+    description: Ansible external epg
+    preferred_group: True
+    state: present
+  register: l2extepg
+
+- name: Verify l2extepg
+  assert:
+    that:
+    - l2extepg.current.0.l2extInstP.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg"
+
+- name: Add L2 external end point group again
+  aci_l2out_extepg:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extepg
+    description: Ansible external epg
+    preferred_group: True
+    state: present
+  register: l2extepg_again
+
+- name: Verify l2extepg_again
+  assert:
+    that:
+    - l2extepg_again is not changed
+    - l2extepg.current.0.l2extInstP.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg"
+
+- name: Add another L2 external end point group
+  aci_l2out_extepg:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out_2
+    extepg: ansible_extepg_2
+    description: Ansible external epg
+    qos_class: level1
+    preferred_group: True
+    state: present
+  register: l2extepg_2
+
+- name: Verify l2extepg_2
+  assert:
+    that:
+    - l2extepg_2.current.0.l2extInstP.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out_2/instP-ansible_extepg_2"
+
+- name: Bind External End Point Groups to Contracts
+  aci_l2out_extepg_to_contract:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extepg
+    contract: ansible_contract
+    contract_type: provider
+    state: present
+  register: bind_extepg_provider_contract
+
+- name: Verify bind_extepg_provider_contract
+  assert:
+    that:
+    - bind_extepg_provider_contract.current.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg/rsprov-ansible_contract"
+
+- name: Bind second External End Point Groups to Contracts
+  aci_l2out_extepg_to_contract:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out_2
+    extepg: ansible_extepg_2
+    contract: ansible_contract2
+    contract_type: provider
+    state: present
+  register: bind_extepg_provider_contract
+
+- name: Verify bind_extepg_provider_contract
+  assert:
+    that:
+    - bind_extepg_provider_contract.current.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out_2/instP-ansible_extepg_2/rsprov-ansible_contract2"
+
+- name: Query the External End Point Groups
+  aci_l2out_extepg_to_contract:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extepg
+    contract: ansible_contract
+    contract_type: provider
+    state: query
+  register: query_extepg
+
+- name: Verify query_extepg
+  assert:
+    that:
+    - query_extepg is not changed
+    - query_extepg.current.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg/rsprov-ansible_contract"
+
+- name: Query all the External End Point Groups
+  aci_l2out_extepg_to_contract:
+    <<: *aci_info
+    contract_type: provider
+    state: query
+  register: query_all
+
+- name: Remove existing contract to External End Point Groups
+  aci_l2out_extepg_to_contract:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extepg
+    contract: ansible_contract
+    contract_type: provider
+    state: absent
+  register: remove_contract_extepg
+
+- name: Verify remove_contract_extepg
+  assert:
+    that:
+    - remove_contract_extepg.previous.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg/rsprov-ansible_contract"
+
+- name: Bind External End Point Groups to Contracts
+  aci_l2out_extepg_to_contract:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l2out: ansible_l2out
+    extepg: ansible_extepg
+    contract: ansible_contract
+    contract_type: consumer
+    provider_match: all
+    state: present
+  ignore_errors: yes
+  register: bind_extepg_consumer_contract
+
+- name: Verify bind_extepg_consumer_contract
+  assert:
+    that:
+    - bind_extepg_consumer_contract.msg == "the 'provider_match' is only configurable for Provided Contracts"

--- a/tests/integration/targets/aci_l2out_extepg_to_contract/tasks/main.yml
+++ b/tests/integration/targets/aci_l2out_extepg_to_contract/tasks/main.yml
@@ -71,6 +71,7 @@
 - name: Verify l2extepg
   assert:
     that:
+    - l2extepg is changed
     - l2extepg.current.0.l2extInstP.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg"
 
 - name: Add L2 external end point group again
@@ -105,6 +106,7 @@
 - name: Verify l2extepg_2
   assert:
     that:
+    - l2extepg_2 is changed
     - l2extepg_2.current.0.l2extInstP.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out_2/instP-ansible_extepg_2"
 
 - name: Bind External End Point Groups to Contracts
@@ -121,6 +123,7 @@
 - name: Verify bind_extepg_provider_contract
   assert:
     that:
+    - bind_extepg_provider_contract is changed
     - bind_extepg_provider_contract.current.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg/rsprov-ansible_contract"
 
 - name: Bind second External End Point Groups to Contracts
@@ -137,6 +140,7 @@
 - name: Verify bind_extepg_provider_contract
   assert:
     that:
+    - bind_extepg_provider_contract is changed
     - bind_extepg_provider_contract.current.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out_2/instP-ansible_extepg_2/rsprov-ansible_contract2"
 
 - name: Query the External End Point Groups
@@ -163,6 +167,12 @@
     state: query
   register: query_all
 
+- name: Verify query_extepg
+  assert:
+    that:
+    - query_extepg is not changed
+    - query_extepg.current | length > 0
+
 - name: Remove existing contract to External End Point Groups
   aci_l2out_extepg_to_contract:
     <<: *aci_info
@@ -177,6 +187,8 @@
 - name: Verify remove_contract_extepg
   assert:
     that:
+    - remove_contract_extepg is changed
+    - remove_contract_extepg.current == []
     - remove_contract_extepg.previous.0.fvRsProv.attributes.dn == "uni/tn-ansible_tenant/l2out-ansible_l2out/instP-ansible_extepg/rsprov-ansible_contract"
 
 - name: Bind External End Point Groups to Contracts
@@ -195,4 +207,5 @@
 - name: Verify bind_extepg_consumer_contract
   assert:
     that:
+    - bind_extepg_consumer_contract is not changed
     - bind_extepg_consumer_contract.msg == "the 'provider_match' is only configurable for Provided Contracts"


### PR DESCRIPTION
This commit add new module module aci_l2out_extepg_to_contract that closely resembles and is based on aci_l3out_extepg_to_contract.