### PR TITLE
Add support for ANSIBLE_NET_SSH_KEYFILE

### DIFF
--- a/plugins/doc_fragments/aci.py
+++ b/plugins/doc_fragments/aci.py
@@ -43,7 +43,7 @@ options:
     - Either a PEM-formatted private key file or the private key content used for signature-based authentication.
     - This value also influences the default C(certificate_name) that is used.
     - This option is mutual exclusive with C(password). If C(password) is provided too, it will be ignored.
-    - If the value is not specified in the task, the value of environment variable C(ACI_PRIVATE_KEY) will be used instead.
+    - If the value is not specified in the task, the value of environment variable C(ACI_PRIVATE_KEY) or C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     type: str
     aliases: [ cert_key ]
   certificate_name:

--- a/plugins/module_utils/aci.py
+++ b/plugins/module_utils/aci.py
@@ -84,7 +84,7 @@ def aci_argument_spec():
         username=dict(type='str', default='admin', aliases=['user'], fallback=(env_fallback, ['ACI_USERNAME', 'ANSIBLE_NET_USERNAME'])),
         password=dict(type='str', no_log=True, fallback=(env_fallback, ['ACI_PASSWORD', 'ANSIBLE_NET_PASSWORD'])),
         # Beware, this is not the same as client_key !
-        private_key=dict(type='str', aliases=['cert_key'], no_log=True, fallback=(env_fallback, ['ACI_PRIVATE_KEY'])),
+        private_key=dict(type='str', aliases=['cert_key'], no_log=True, fallback=(env_fallback, ['ACI_PRIVATE_KEY', 'ANSIBLE_NET_SSH_KEYFILE'])),
         # Beware, this is not the same as client_cert !
         certificate_name=dict(type='str', aliases=['cert_name'], fallback=(env_fallback, ['ACI_CERTIFICATE_NAME'])),
         output_level=dict(type='str', default='normal', choices=['debug', 'info', 'normal'], fallback=(env_fallback, ['ACI_OUTPUT_LEVEL'])),


### PR DESCRIPTION
This change adds to the work done in https://github.com/CiscoDevNet/ansible-aci/pull/96. It completes support for the Network credential type in AWX/Tower when using signature-based authentication.