### PR TITLE
Fixed the behavior when output is specified in aci_rest.

### DIFF
--- a/plugins/modules/aci_rest.py
+++ b/plugins/modules/aci_rest.py
@@ -441,10 +441,10 @@ def main():
     aci.result['totalCount'] = aci.totalCount
 
     if aci.params.get('method') != 'get':
-      output_path = aci.params.get('output_path')
-      if(output_path is not None):
-          with open(output_path, "a") as output_file:
-              json.dump([payload_output_file], output_file)
+        output_path = aci.params.get('output_path')
+        if(output_path is not None):
+            with open(output_path, "a") as output_file:
+                json.dump([payload_output_file], output_file)
 
     # Report success
     aci.exit_json(**aci.result)

--- a/plugins/modules/aci_rest.py
+++ b/plugins/modules/aci_rest.py
@@ -369,11 +369,6 @@ def main():
 
     # We include the payload as it may be templated
     payload = content
-    if file_exists:
-        with open(src, 'r') as config_object:
-            # TODO: Would be nice to template this, requires action-plugin
-            payload = config_object.read()
-            payload_output_file = json.loads(payload)
 
     # Validate payload
     if rest_type == 'json':
@@ -396,6 +391,15 @@ def main():
                 payload = etree.tostring(etree.fromstring(payload))
             except Exception as e:
                 module.fail_json(msg='Failed to parse provided XML payload: %s' % to_text(e), payload=payload)
+
+    # CHANGED: Move from 372
+    if file_exists:
+        with open(src, 'r') as config_object:
+            # TODO: Would be nice to template this, requires action-plugin
+            payload = config_object.read()
+            payload_output_file = json.loads(payload)
+    elif payload:
+      payload_output_file = json.loads(payload)
 
     # Perform actual request using auth cookie (Same as aci.request(), but also supports XML)
     if 'port' in aci.params and aci.params.get('port') is not None:
@@ -438,10 +442,11 @@ def main():
     aci.result['imdata'] = aci.imdata
     aci.result['totalCount'] = aci.totalCount
 
-    output_path = aci.params.get('output_path')
-    if(output_path is not None):
-        with open(output_path, "a") as output_file:
-            json.dump([payload_output_file], output_file)
+    if aci.params.get('method') != 'get':
+      output_path = aci.params.get('output_path')
+      if(output_path is not None):
+          with open(output_path, "a") as output_file:
+              json.dump([payload_output_file], output_file)
 
     # Report success
     aci.exit_json(**aci.result)

--- a/plugins/modules/aci_rest.py
+++ b/plugins/modules/aci_rest.py
@@ -369,16 +369,23 @@ def main():
 
     # We include the payload as it may be templated
     payload = content
+    if file_exists:
+        with open(src, 'r') as config_object:
+            # TODO: Would be nice to template this, requires action-plugin
+            payload = config_object.read()
+            payload_output_file = json.loads(payload)
 
     # Validate payload
     if rest_type == 'json':
         if content and isinstance(content, dict):
             # Validate inline YAML/JSON
             payload = json.dumps(payload)
+            payload_output_file = json.loads(payload)
         elif payload and isinstance(payload, str) and HAS_YAML:
             try:
                 # Validate YAML/JSON string
                 payload = json.dumps(yaml.safe_load(payload))
+                payload_output_file = json.loads(payload)
             except Exception as e:
                 module.fail_json(msg='Failed to parse provided JSON/YAML payload: %s' % to_text(e), exception=to_text(e), payload=payload)
     elif rest_type == 'xml' and HAS_LXML_ETREE:
@@ -391,15 +398,6 @@ def main():
                 payload = etree.tostring(etree.fromstring(payload))
             except Exception as e:
                 module.fail_json(msg='Failed to parse provided XML payload: %s' % to_text(e), payload=payload)
-
-    # CHANGED: Move from 372
-    if file_exists:
-        with open(src, 'r') as config_object:
-            # TODO: Would be nice to template this, requires action-plugin
-            payload = config_object.read()
-            payload_output_file = json.loads(payload)
-    elif payload:
-      payload_output_file = json.loads(payload)
 
     # Perform actual request using auth cookie (Same as aci.request(), but also supports XML)
     if 'port' in aci.params and aci.params.get('port') is not None:


### PR DESCRIPTION
Addresses issue https://github.com/CiscoDevNet/ansible-aci/issues/162

Skip output_file when "Method: Get" is used
Change to generate file when "Method: Post/Delete".

Requesting by xml is not supported.