### PR TITLE
l3out interface enhancements

### DIFF
--- a/plugins/modules/aci_l3out_interface.py
+++ b/plugins/modules/aci_l3out_interface.py
@@ -67,6 +67,12 @@ options:
     description:
     - IP address.
     type: str
+  ipv6_dad:
+    description:
+    - IPv6 DAD feature.
+    type: str
+    choices: [ enabled, disabled]
+    default: enabled
   interface_type:
     description:
     - Type of interface to build.
@@ -95,6 +101,7 @@ seealso:
   link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Tim Cragg (@timcragg)
+- Marcel Zehnder (@maercu)
 '''
 
 EXAMPLES = r'''
@@ -291,6 +298,8 @@ def main():
         node_id=dict(type='str', required=True),
         path_ep=dict(type='str', required=True),
         addr=dict(type='str'),
+        ipv6_dad=dict(type='str', default='enabled',
+                      choices=['enabled', 'disabled']),
         interface_type=dict(type='str',
                             choices=['l3-port', 'sub-interface', 'ext-svi']),
         mode=dict(type='str',
@@ -315,6 +324,7 @@ def main():
     node_id = module.params.get('node_id')
     path_ep = module.params.get('path_ep')
     addr = module.params.get('addr')
+    ipv6_dad = module.params.get('ipv6_dad')
     interface_type = module.params.get('interface_type')
     mode = module.params.get('mode')
     encap = module.params.get('encap')
@@ -371,6 +381,7 @@ def main():
             class_config=dict(
                 tDn=path_dn,
                 addr=addr,
+                ipv6Dad=ipv6_dad,
                 ifInstT=interface_type,
                 mode=mode,
                 encap=encap

--- a/plugins/modules/aci_l3out_interface_secondary_ip.py
+++ b/plugins/modules/aci_l3out_interface_secondary_ip.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_l3out_interface_secondary_ip:
+module: aci_l3out_interface_secondary_ip
 short_description: Manage Layer 3 Outside (L3Out) interface secondary IP addresses (l3ext:Ip).
 description:
 - Manage Layer 3 Outside (L3Out) interface secondary IP addresses (l3ext:Ip).
@@ -258,6 +258,7 @@ url:
 
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     argument_spec = aci_argument_spec()

--- a/plugins/modules/aci_l3out_logical_interface_vpc_member.py
+++ b/plugins/modules/aci_l3out_logical_interface_vpc_member.py
@@ -282,6 +282,7 @@ url:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec
 
+
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(
@@ -330,9 +331,9 @@ def main():
     name_alias = module.params.get('name_alias')
 
     if not path_dn:
-      path_dn = ('topology/pod-{0}/protpaths-{1}/pathep-[{2}]'.format(pod_id,
-                                                                      node_id,
-                                                                      path_ep))
+        path_dn = ('topology/pod-{0}/protpaths-{1}/pathep-[{2}]'.format(pod_id,
+                                                                        node_id,
+                                                                        path_ep))
     aci.construct_url(
         root_class=dict(
             aci_class='fvTenant',

--- a/tests/integration/targets/aci_l3out_interface/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_interface/tasks/main.yml
@@ -131,6 +131,7 @@
     interface_type: l3-port
     mode: regular
     addr: 192.168.50.1/27
+    ipv6_dad: disabled
     state: present
   register: add_l3out_interface
 
@@ -139,6 +140,7 @@
     that:
     - add_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.dn == "uni/tn-ansible_tenant/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[eth1/15]]"
     - add_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.addr == "192.168.50.1/27"
+    - add_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.ipv6Dad == "disabled"
     - add_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.ifInstT == "l3-port"
     - add_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.mode == "regular"
 
@@ -156,6 +158,7 @@
     interface_type: l3-port
     mode: regular
     addr: 192.168.50.1/27
+    ipv6_dad: disabled
     state: present
   register: add_l3out_interface_again
 

--- a/tests/integration/targets/aci_l3out_interface_secondary_ip/aliases
+++ b/tests/integration/targets/aci_l3out_interface_secondary_ip/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_l3out_interface_secondary_ip/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_interface_secondary_ip/tasks/main.yml
@@ -1,0 +1,496 @@
+# Test code for the ACI modules
+# Copyright: (c) 2021, Tim Cragg (@timcragg)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+# GET Credentials from the inventory
+- name: Set vars
+  set_fact:
+    aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: debug
+
+# CLEAN ENVIRONMENT
+- name: Remove test tenant if it already exists
+  aci_tenant:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    state: absent
+
+- name: Remove port-channel IPG
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    lag_type: link
+    policy_group: ansible_port_channel_ipg
+    state: absent
+
+- name: Remove vPC IPG
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    lag_type: node
+    policy_group: ansible_vpc_ipg
+    state: absent
+
+# ADD PC IPG
+- name: Add port-channel IPG
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    lag_type: link
+    policy_group: ansible_port_channel_ipg
+    state: present
+
+# ADD vPC IPG
+- name: Add vPC IPG
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    lag_type: node
+    policy_group: ansible_vpc_ipg
+    state: present
+
+# ADD domain
+- name: Add domain for l3out
+  aci_domain:
+    <<: *aci_info
+    domain: ansible_l3ext_domain
+    domain_type: l3dom
+    state: present
+
+# ADD tenant
+- name: Add a new tenant required for l3out
+  aci_tenant:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    description: Ansible tenant
+    state: present
+
+# ADD VRF
+- name: Add VRF for l3out
+  aci_vrf:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    vrf: ansible_vrf
+    state: present
+
+# ADD l3out
+- name: Add l3out
+  aci_l3out:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    name: ansible_l3out
+    vrf: ansible_vrf
+    domain: ansible_domain
+    route_control: export
+    state: present
+
+# ADD l3out logical node profile
+- name: l3out logical node profile
+  aci_l3out_logical_node_profile:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    state: present
+
+# ADD l3out logical interface profile
+- name: l3out logical interface profile
+  aci_l3out_logical_interface_profile:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    state: present
+
+# ADD l3out routed interface
+- name: Add routed interface
+  aci_l3out_interface:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: eth1/15
+    interface_type: l3-port
+    mode: regular
+    addr: 192.168.50.1/27
+    state: present
+
+# ADD l3out routed interface po
+- name: Add routed interface port-channel
+  aci_l3out_interface:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: ansible_port_channel_ipg
+    interface_type: l3-port
+    mode: regular
+    addr: 192.168.70.1/27
+    state: present
+
+# ADD l3out routed interface vPC
+- name: Add routed interface vPC
+  aci_l3out_interface:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    interface_type: ext-svi
+    mode: native
+    encap: vlan-913
+    state: present
+
+# ADD l3out routed interface vPC member
+- name: Add routed interface vPC member
+  aci_l3out_logical_interface_vpc_member:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    side: A
+    addr: 192.168.90.1/27
+    state: present
+
+# ADD secondary IPs to the interfaces
+- name: Add secondary IP to routed interface
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: eth1/15
+    addr: 192.168.50.2/27
+    ipv6_dad: disabled
+    state: present
+  register: secondary_intf
+
+- name: Add secondary to IP routed interface port-channel
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: ansible_port_channel_ipg
+    addr: 192.168.70.2/27
+    ipv6_dad: disabled
+    state: present
+  register: secondary_po
+
+- name: Add  secondary IP to routed interface vPC
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    side: A
+    addr: 192.168.90.2/27
+    ipv6_dad: disabled
+    state: present
+  register: secondary_vpc
+
+- name: Verify secondaries have been created with the correct attributes
+  assert:
+    that:
+    - secondary_intf.current.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[eth1/15]]/addr-[192.168.50.2/27]"
+    - secondary_intf.current.0.l3extIp.attributes.ipv6Dad == "disabled"
+    - secondary_po.current.0.l3extIp.attributes.dn== "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[ansible_port_channel_ipg]]/addr-[192.168.70.2/27]"
+    - secondary_po.current.0.l3extIp.attributes.ipv6Dad == "disabled"
+    - secondary_vpc.current.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/protpaths-201-202/pathep-[ansible_vpc_ipg]]/mem-A/addr-[192.168.90.2/27]"
+    - secondary_vpc.current.0.l3extIp.attributes.ipv6Dad == "disabled"
+
+# CHECK idempotency
+- name: Add secondary IP to routed interface with no changes
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: eth1/15
+    addr: 192.168.50.2/27
+    ipv6_dad: disabled
+    state: present
+  register: secondary_intf_again
+
+- name: Add secondary to IP routed interface port-channel with no changes
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: ansible_port_channel_ipg
+    addr: 192.168.70.2/27
+    ipv6_dad: disabled
+    state: present
+  register: secondary_po_again
+
+- name: Add  secondary IP to routed interface vPC with no changes
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    side: A
+    addr: 192.168.90.2/27
+    ipv6_dad: disabled
+    state: present
+  register: secondary_vpc_again
+
+- name: Verify MOs have not changed
+  assert:
+    that:
+    - secondary_intf_again is not changed
+    - secondary_po_again is not changed
+    - secondary_vpc_again is not changed
+
+# CHECK updates/modifications
+- name: Modify routed interface
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: eth1/15
+    addr: 192.168.50.2/27
+    ipv6_dad: enabled
+    state: present
+  register: secondary_intf_update
+
+- name: Modify routed port-channel
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: ansible_port_channel_ipg
+    addr: 192.168.70.2/27
+    ipv6_dad: enabled
+    state: present
+  register: secondary_po_update
+
+- name: Modify routed vPC
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    side: A
+    addr: 192.168.90.2/27
+    ipv6_dad: enabled
+    state: present
+  register: secondary_vpc_update
+
+- name: Verify updates have been applied
+  assert:
+    that:
+    - secondary_intf_update is changed
+    - secondary_po_update is changed
+    - secondary_vpc_update is changed
+    - secondary_intf_update.current.0.l3extIp.attributes.ipv6Dad == "enabled"
+    - secondary_po_update.current.0.l3extIp.attributes.ipv6Dad == "enabled"
+    - secondary_vpc_update.current.0.l3extIp.attributes.ipv6Dad == "enabled"
+
+# QUERIES
+- name: Query secondary for interface
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: eth1/15
+    addr: 192.168.50.2/27
+    ipv6_dad: enabled
+    state: query
+  register: secondary_intf_query
+
+- name: Query secondary for po
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: ansible_port_channel_ipg
+    addr: 192.168.70.2/27
+    ipv6_dad: enabled
+    state: query
+  register: secondary_po_query
+
+- name: Query secondary for vpc
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    side: A
+    addr: 192.168.90.2/27
+    ipv6_dad: enabled
+    state: query
+  register: secondary_vpc_query
+
+- name: Query all secondary IPs
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    state: query
+  register: secondary_all_query
+
+- name: Verify queries
+  assert:
+    that:
+    - secondary_intf_query is not changed
+    - secondary_po_query is not changed
+    - secondary_vpc_query is not changed
+    - secondary_intf_query.current.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[eth1/15]]/addr-[192.168.50.2/27]"
+    - secondary_intf_query.current.0.l3extIp.attributes.ipv6Dad == "enabled"
+    - secondary_po_query.current.0.l3extIp.attributes.dn== "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[ansible_port_channel_ipg]]/addr-[192.168.70.2/27]"
+    - secondary_po_query.current.0.l3extIp.attributes.ipv6Dad == "enabled"
+    - secondary_vpc_query.current.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/protpaths-201-202/pathep-[ansible_vpc_ipg]]/mem-A/addr-[192.168.90.2/27]"
+    - secondary_vpc_query.current.0.l3extIp.attributes.ipv6Dad == "enabled"
+    - secondary_all_query.current|length > 1
+
+# DELETE secondary IPs
+- name: Delete secondary for interface
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: eth1/15
+    addr: 192.168.50.2/27
+    ipv6_dad: enabled
+    state: absent
+  register: secondary_intf_remove
+
+- name: Delete secondary for po
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201
+    path_ep: ansible_port_channel_ipg
+    addr: 192.168.70.2/27
+    ipv6_dad: enabled
+    state: absent
+  register: secondary_po_remove
+
+- name: Delete secondary for vpc
+  aci_l3out_interface_secondary_ip:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    l3out: ansible_l3out
+    node_profile: ansible_node_profile
+    interface_profile: ansible_interface_profile
+    pod_id: 1
+    node_id: 201-202
+    path_ep: ansible_vpc_ipg
+    side: A
+    addr: 192.168.90.2/27
+    ipv6_dad: enabled
+    state: absent
+  register: secondary_vpc_remove
+
+- name: Verify objects have been deleted
+  assert:
+    that:
+    - secondary_intf_remove.current == []
+    - secondary_po_remove.current == []
+    - secondary_vpc_remove.current == []
+    - secondary_intf_remove.previous.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[eth1/15]]/addr-[192.168.50.2/27]"
+    - secondary_po_remove.previous.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/paths-201/pathep-[ansible_port_channel_ipg]]/addr-[192.168.70.2/27]"
+    - secondary_vpc_remove.previous.0.l3extIp.attributes.dn == "uni/tn-ansible_l3_secondary/out-ansible_l3out/lnodep-ansible_node_profile/lifp-ansible_interface_profile/rspathL3OutAtt-[topology/pod-1/protpaths-201-202/pathep-[ansible_vpc_ipg]]/mem-A/addr-[192.168.90.2/27]"
+ 
+
+# CLEAN UP
+- name: Remove tenant
+  aci_tenant:
+    <<: *aci_info
+    tenant: ansible_l3_secondary
+    state: absent
+
+- name: Remove ext domain
+  aci_domain:
+    <<: *aci_info
+    domain: ansible_l3ext_domain
+    domain_type: l3dom
+    state: absent
+
+- name: Remove port-channel
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    lag_type: link
+    policy_group: ansible_port_channel_ipg
+    state: absent
+
+- name: Remove vpc
+  aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    lag_type: node
+    policy_group: ansible_vpc_ipg
+    state: absent

--- a/tests/integration/targets/aci_l3out_logical_interface_vpc_member/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_logical_interface_vpc_member/tasks/main.yml
@@ -45,39 +45,40 @@
     route_control: export
     state: present
 
-- name: Add a new logical node
-  cisco.aci.aci_rest:
+- name: Add a new logical node profile
+  cisco.aci.aci_l3out_logical_node_profile: 
     <<: *aci_info
-    path: /api/mo/uni/tn-ansible_tenant/out-ansible_l3out.json
-    method: post
-    content:
-      {
-          "l3extLNodeP": {
-              "attributes": {
-                  "dn": "uni/tn-ansible_tenant/out-ansible_l3out/lnodep-ansible_LNode",
-                  "name": "ansible_LNode"
-              },
-              "children": [{
-                  "l3extLIfP": {
-                      "attributes": {
-                          "name": "ansible_LInterface"
-                      },
-                      "children": [{
-                          "l3extRsPathL3OutAtt": {
-                              "attributes": {
-                                  "addr": "0.0.0.0",
-                                  "encap": "vlan-100",
-                                  "ifInstT": "ext-svi",
-                                  "tDn": "topology/pod-1/protpaths-101-102/pathep-[policy_group_one]"
-                              }
-                          }
-                      }]
-                  }
-              }]
-          }
-      }
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    node_profile: ansible_LNode
+    state: present
 
-- name: Add a VPC member
+- name: Add a interface profile
+  cisco.aci.aci_l3out_logical_interface_profile: 
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    node_profile: ansible_LNode
+    interface_profile: ansible_LInterface
+    state: present
+
+- name: Add two vPC-interfaces
+  aci_l3out_interface:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    node_profile: ansible_LNode
+    interface_profile: ansible_LInterface
+    pod_id: 1
+    node_id: 101-102
+    path_ep: "{{ item }}"
+    interface_type: ext-svi
+    state: present
+  loop:
+    - policy_group_one
+    - policy_group_two
+
+- name: Add a VPC member based on path_dn
   aci_l3out_logical_interface_vpc_member:
     <<: *aci_info
     tenant: ansible_tenant
@@ -86,6 +87,21 @@
     logical_interface: ansible_LInterface
     path_dn: topology/pod-1/protpaths-101-102/pathep-[policy_group_one]
     side: A
+    state: present
+
+- name: Add a VPC member based on pod_id, node_id, path_ep
+  aci_l3out_logical_interface_vpc_member:
+    <<: *aci_info
+    tenant: ansible_tenant
+    l3out: ansible_l3out
+    node_profile: ansible_LNode
+    interface_profile: ansible_LInterface
+    pod_id: 1
+    node_id: 101-102
+    path_ep: policy_group_two
+    side: A
+    addr: 192.168.1.254/24
+    ipv6_dad: disabled
     state: present
 
 - name: Query a specific VPC member under ansible_l3out


### PR DESCRIPTION
### aci_l3out_interface updated
- added ipv6Dad attribute

### aci_l3out_logical_interface_vpc_member
- renamed arguments for node and interface profiles (inline with the other l3out modules)
- added arguments to describe fabricPathEp with pod_id, node_id, path_ep (inline with aci_l3out_interface module)
- added addr attribute
- added ipv6Dad attribute

### aci_l3out_interface_secondary_ip
- new module  to manage l3out interface secondary IP addresses (l3ext:Ip)