### PR TITLE
aci_vlan_pool_encap_block - Removed block_name from the required parameter list

### DIFF
--- a/plugins/modules/aci_vlan_pool_encap_block.py
+++ b/plugins/modules/aci_vlan_pool_encap_block.py
@@ -89,6 +89,7 @@ EXAMPLES = r"""
     username: admin
     password: SomeSecretPassword
     pool: production
+    pool_allocation_mode: static
     block_start: 20
     block_end: 50
     state: present
@@ -100,6 +101,7 @@ EXAMPLES = r"""
     username: admin
     password: SomeSecretPassword
     pool: production
+    pool_allocation_mode: static
     block_start: 20
     block_end: 50
     state: absent
@@ -111,6 +113,7 @@ EXAMPLES = r"""
     username: admin
     password: SomeSecretPassword
     pool: production
+    pool_allocation_mode: static
     block_start: 20
     block_end: 50
     state: query
@@ -123,6 +126,7 @@ EXAMPLES = r"""
     username: admin
     password: SomeSecretPassword
     pool: production
+    pool_allocation_mode: static
     state: query
   delegate_to: localhost
   register: query_result
@@ -264,8 +268,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "absent", ["pool", "block_end", "block_name", "block_start"]],
-            ["state", "present", ["pool", "block_end", "block_name", "block_start"]],
+            ['state', 'absent', ['pool', 'pool_allocation_mode', 'block_end', 'block_start']],
+            ['state', 'present', ['pool', 'pool_allocation_mode', 'block_end', 'block_start']],
         ],
     )
 

--- a/tests/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
+++ b/tests/integration/targets/aci_vlan_pool_encap_block/tasks/main.yml
@@ -20,7 +20,7 @@
     output_level: '{{ aci_output_level | default("info") }}'
     state: absent
     pool: anstest
-    allocation_mode: static
+    pool_allocation_mode: static
     description: Ansible Test
 
 - name: Ensure vlan pool exists for tests to kick off
@@ -34,7 +34,7 @@
     output_level: debug
     state: present
     pool: anstest
-    allocation_mode: static
+    pool_allocation_mode: static
     description: Ansible Test
   register: pool_present
 
@@ -188,20 +188,7 @@
   assert:
     that:
       - encap_block_present_missing_param is failed
-      - 'encap_block_present_missing_param.msg == "state is present but all of the following are missing: block_end, block_name, block_start"'
-
-- name: Missing required param - error message works
-  cisco.aci.aci_vlan_pool_encap_block:
-    <<: *aci_encap_block_present
-    pool_allocation_mode: "{{ fake_var | default(omit) }}"
-  ignore_errors: yes
-  register: encap_block_present_allocation
-
-- name: Present assertions
-  assert:
-    that:
-      - encap_block_present_allocation is failed
-      - encap_block_present_allocation.msg == "ACI requires the 'pool_allocation_mode' when 'pool' is provided"
+      - 'encap_block_present_missing_param.msg == "state is present but all of the following are missing: block_end, block_start"'
 
 - name: Query specific vlan pool range
   cisco.aci.aci_vlan_pool_encap_block: &aci_encap_block_query


### PR DESCRIPTION
Removed block_name from the required parameter list and added pool_allocation_mode to the required parameter list.

Deleted pool_allocation_mode - **Missing required param - error message works** test case because it is invalid check for the current code.