### PR TITLE
Added fex_port_channel and fex_vpc interface types access_port_to_interface_policy_leaf_profile

### DIFF
--- a/plugins/modules/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/plugins/modules/aci_access_port_to_interface_policy_leaf_profile.py
@@ -306,14 +306,16 @@ url:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec, aci_owner_spec
 
+port_channels_dn = "uni/infra/funcprof/accbundle-{0}"
+
 INTERFACE_TYPE_MAPPING = dict(
     breakout="uni/infra/funcprof/brkoutportgrp-{0}",
     fex="uni/infra/funcprof/accportgrp-{0}",
-    port_channel="uni/infra/funcprof/accbundle-{0}",
+    port_channel=port_channels_dn,
     switch_port="uni/infra/funcprof/accportgrp-{0}",
-    vpc="uni/infra/funcprof/accbundle-{0}",
-    fex_port_channel="uni/infra/funcprof/accbundle-{0}",
-    fex_vpc="uni/infra/funcprof/accbundle-{0}",
+    vpc=port_channels_dn,
+    fex_port_channel=port_channels_dn,
+    fex_vpc=port_channels_dn,
 )
 
 

--- a/plugins/modules/aci_access_port_to_interface_policy_leaf_profile.py
+++ b/plugins/modules/aci_access_port_to_interface_policy_leaf_profile.py
@@ -94,7 +94,7 @@ options:
     description:
     - The type of interface for the static EPG deployment.
     type: str
-    choices: [ breakout, fex, port_channel, switch_port, vpc ]
+    choices: [ breakout, fex, port_channel, switch_port, vpc, fex_port_channel, fex_vpc]
     default: switch_port
   type:
     description:
@@ -312,6 +312,8 @@ INTERFACE_TYPE_MAPPING = dict(
     port_channel="uni/infra/funcprof/accbundle-{0}",
     switch_port="uni/infra/funcprof/accportgrp-{0}",
     vpc="uni/infra/funcprof/accbundle-{0}",
+    fex_port_channel="uni/infra/funcprof/accbundle-{0}",
+    fex_vpc="uni/infra/funcprof/accbundle-{0}",
 )
 
 
@@ -330,7 +332,9 @@ def main():
         from_card=dict(type="str", aliases=["from_card_range"]),
         to_card=dict(type="str", aliases=["to_card_range"]),
         policy_group=dict(type="str", aliases=["policy_group_name"]),
-        interface_type=dict(type="str", default="switch_port", choices=["breakout", "fex", "port_channel", "switch_port", "vpc"]),
+        interface_type=dict(
+            type="str", default="switch_port", choices=["breakout", "fex", "port_channel", "switch_port", "vpc", "fex_port_channel", "fex_vpc"]
+        ),
         type=dict(type="str", default="leaf", choices=["fex", "leaf"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
     )

--- a/tests/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/tests/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -9,6 +9,18 @@
     msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
   when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
 
+# SET VARS
+- name: Set vars
+  set_fact:
+    aci_info: &aci_info
+      host: '{{ aci_hostname }}'
+      username: '{{ aci_username }}'
+      password: '{{ aci_password }}'
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: '{{ aci_output_level | default("info") }}'
+
 - name: Remove Interface policy leaf profile - Cleanup
   cisco.aci.aci_interface_policy_leaf_profile: &aci_interface_policy_leaf_profile_absent
     host: "{{ aci_hostname }}"
@@ -203,3 +215,204 @@
     type: fex
     leaf_interface_profile: fexintprftest
     state: absent
+
+- name: Add anstest_fex_port_channel - Interface Policy Leaf Profile with type Fex
+  cisco.aci.aci_interface_policy_leaf_profile: &anstest_fex_port_channel_present
+    <<: *aci_interface_policy_leaf_profile_present
+    type: fex
+    leaf_interface_profile: anstest_fex_port_channel
+
+- name: Add policygroupname_link_fpc - Policy Group with lag type link
+  cisco.aci.aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    policy_group: policygroupname_link_fpc
+    lag_type: link
+    link_level_policy: linklevelpolicy
+    fibre_channel_interface_policy: fiberchannelpolicy
+    state: present
+
+- name: Bind anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - check mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile: &cm_fpc_present
+    <<: *anstest_fex_port_channel_present
+    interface_type: fex_port_channel
+    access_port_selector: anstest_fex_port_channel
+    policy_group: policygroupname_link_fpc
+  check_mode: yes
+  register: cm_fpc_present
+
+- name: Assertion check for bind anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - check mode
+  assert:
+    that:
+    - cm_fpc_present.current | length == 0
+    - cm_fpc_present.previous | length == 0
+    - cm_fpc_present.sent.infraHPortS.attributes.name == "anstest_fex_port_channel"
+    - cm_fpc_present.sent.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_link_fpc"
+
+- name: Bind anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - normal mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile: &nm_fpc_present
+    <<: *cm_fpc_present
+  register: nm_fpc_present
+
+- name: Assertion check for bind anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - normal mode
+  assert:
+    that:
+    - nm_fpc_present.current | length == 1
+    - nm_fpc_present.previous | length == 0
+    - nm_fpc_present.current.0.infraHPortS.attributes.name == "anstest_fex_port_channel"
+    - nm_fpc_present.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_link_fpc"
+    - nm_fpc_present.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+
+- name: Remove anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - check mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile: &cm_fpc_absent
+    <<: *nm_fpc_present
+    state: absent
+  check_mode: yes
+  register: cm_fpc_absent
+
+- name: Assertion check for remove anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - check mode
+  assert:
+    that:
+    - cm_fpc_absent.current | length == 1
+    - cm_fpc_absent.previous | length == 1
+    - cm_fpc_absent.current.0.infraHPortS.attributes.name == "anstest_fex_port_channel"
+    - cm_fpc_absent.previous.0.infraHPortS.attributes.name == "anstest_fex_port_channel"
+    - cm_fpc_absent.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_link_fpc"
+    - cm_fpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_link_fpc"
+    - cm_fpc_absent.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+    - cm_fpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+
+- name: Remove anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - normal mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile:
+    <<: *cm_fpc_absent
+  register: nm_fpc_absent
+
+- name: Assertion check for remove anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - normal mode
+  assert:
+    that:
+    - nm_fpc_absent.current | length == 0
+    - nm_fpc_absent.previous | length == 1
+    - nm_fpc_absent.previous.0.infraHPortS.attributes.name == "anstest_fex_port_channel"
+    - nm_fpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_link_fpc"
+    - nm_fpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+
+- name: Add anstest_fex_vpc - Interface Policy Leaf Profile with type Fex
+  cisco.aci.aci_interface_policy_leaf_profile: &anstest_fex_vpc
+    <<: *aci_interface_policy_leaf_profile_present
+    type: fex
+    leaf_interface_profile: anstest_fex_vpc
+  register: anstest_fex_vpc_present
+
+- name: Assertion check for add anstest_fex_vpc - Interface Policy Leaf Profile with type Fex
+  assert:
+    that:
+    - anstest_fex_vpc_present.current | length == 1
+    - anstest_fex_vpc_present.current.0.infraFexP.attributes.name == "anstest_fex_vpc"
+    - anstest_fex_vpc_present.current.0.infraFexP.attributes.dn == "uni/infra/fexprof-anstest_fex_vpc"
+
+- name: Add policygroupname_node_fvpc - Policy Group with lag type node
+  cisco.aci.aci_interface_policy_leaf_policy_group:
+    <<: *aci_info
+    policy_group: policygroupname_node_fvpc
+    lag_type: node
+    link_level_policy: linklevelpolicy
+    fibre_channel_interface_policy: fiberchannelpolicy
+    state: present
+  register: policygroupname_node_fvpc_present
+
+- name: Assertion check for add policygroupname_node_fvpc - Policy Group with lag type node
+  assert:
+    that:
+    - policygroupname_node_fvpc_present.current | length == 1
+    - policygroupname_node_fvpc_present.current.0.infraAccBndlGrp.attributes.name == "policygroupname_node_fvpc"
+    - policygroupname_node_fvpc_present.current.0.infraAccBndlGrp.attributes.lagT == "node"
+
+- name: Bind anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - check mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile: &cm_fex_vpc_present
+    <<: *anstest_fex_vpc
+    interface_type: fex_vpc
+    access_port_selector: anstest_fex_vpc
+    policy_group: policygroupname_node_fvpc
+  check_mode: yes
+  register: cm_fex_vpc_present
+
+- name: Assertion check for bind anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - check mode
+  assert:
+    that:
+    - cm_fex_vpc_present.current | length == 0
+    - cm_fex_vpc_present.previous | length == 0
+    - cm_fex_vpc_present.sent.infraHPortS.attributes.name == "anstest_fex_vpc"
+    - cm_fex_vpc_present.sent.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_node_fvpc"
+
+- name: Bind anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - normal mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile:
+    <<: *cm_fex_vpc_present
+  register: nm_fex_vpc_present
+
+- name: Assertion check for bind anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - normal mode
+  assert:
+    that:
+    - nm_fex_vpc_present.current | length == 1
+    - nm_fex_vpc_present.previous | length == 0
+    - nm_fex_vpc_present.current.0.infraHPortS.attributes.name == "anstest_fex_vpc"
+    - nm_fex_vpc_present.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+    - nm_fex_vpc_present.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_node_fvpc"
+
+- name: Remove anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - check mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile: &cm_fex_vpc_absent
+    <<: *cm_fex_vpc_present
+    state: absent
+  check_mode: yes
+  register: cm_fex_vpc_absent
+
+- name: Assertion check for remove anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - check mode
+  assert:
+    that:
+    - cm_fex_vpc_absent.current | length == 1
+    - cm_fex_vpc_absent.previous | length == 1
+    - cm_fex_vpc_absent.current.0.infraHPortS.attributes.name == "anstest_fex_vpc"
+    - cm_fex_vpc_absent.previous.0.infraHPortS.attributes.name == "anstest_fex_vpc"
+    - cm_fex_vpc_absent.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+    - cm_fex_vpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+    - cm_fex_vpc_absent.current.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_node_fvpc"
+    - cm_fex_vpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_node_fvpc"
+
+- name: Remove anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - normal mode
+  cisco.aci.aci_access_port_to_interface_policy_leaf_profile:
+    <<: *cm_fex_vpc_absent
+  register: nm_fex_vpc_absent
+
+- name: Assertion check for remove anstest_fex_vpc Access Port Selector with policygroupname_node_fvpc Policy Group - normal mode
+  assert:
+    that:
+    - nm_fex_vpc_absent.current | length == 0
+    - nm_fex_vpc_absent.previous | length == 1
+    - nm_fex_vpc_absent.previous.0.infraHPortS.attributes.name == "anstest_fex_vpc"
+    - nm_fex_vpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.fexId == "101"
+    - nm_fex_vpc_absent.previous.0.infraHPortS.children.0.infraRsAccBaseGrp.attributes.tDn == "uni/infra/funcprof/accbundle-policygroupname_node_fvpc"
+
+# Removing profiles
+- name: Remove anstest_fex_vpc - Interface Policy Leaf Profile with type Fex
+  cisco.aci.aci_interface_policy_leaf_profile:
+    <<: *anstest_fex_vpc
+    state: absent
+  register: anstest_fex_vpc_absent
+
+- name: Assertion check for remove anstest_fex_vpc - Interface Policy Leaf Profile with type Fex
+  assert:
+    that:
+    - anstest_fex_vpc_absent.current | length == 0
+    - anstest_fex_vpc_absent.previous | length == 1
+    - anstest_fex_vpc_absent.previous.0.infraFexP.attributes.name == "anstest_fex_vpc"
+
+- name: Remove anstest_fex_port_channel - Interface Policy Leaf Profile with type Fex
+  cisco.aci.aci_interface_policy_leaf_profile:
+    <<: *anstest_fex_port_channel_present
+    state: absent
+  register: anstest_fex_port_channel_absent
+
+- name: Assertion check for remove anstest_fex_port_channel - Interface Policy Leaf Profile with type Fex
+  assert:
+    that:
+    - anstest_fex_port_channel_absent.current | length == 0
+    - anstest_fex_port_channel_absent.previous | length == 1
+    - anstest_fex_port_channel_absent.previous.0.infraFexP.attributes.name == "anstest_fex_port_channel"

--- a/tests/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
+++ b/tests/integration/targets/aci_access_port_to_interface_policy_leaf_profile/tasks/main.yml
@@ -227,8 +227,8 @@
     <<: *aci_info
     policy_group: policygroupname_link_fpc
     lag_type: link
-    link_level_policy: linklevelpolicy
-    fibre_channel_interface_policy: fiberchannelpolicy
+    link_level_policy: link_level_policy
+    fibre_channel_interface_policy: fiber_channel_policy
     state: present
 
 - name: Bind anstest_fex_port_channel Access Port Selector with policygroupname_link_fpc Policy Group - check mode
@@ -314,8 +314,8 @@
     <<: *aci_info
     policy_group: policygroupname_node_fvpc
     lag_type: node
-    link_level_policy: linklevelpolicy
-    fibre_channel_interface_policy: fiberchannelpolicy
+    link_level_policy: link_level_policy
+    fibre_channel_interface_policy: fiber_channel_policy
     state: present
   register: policygroupname_node_fvpc_present
 


### PR DESCRIPTION
Note:

Added fex_port_channel, fex_vpc interface types access_port_to_interface_policy_leaf_profile module and updated testcases.