### PR TITLE
return correct http status code in aci_rest module

### DIFF
--- a/plugins/modules/aci_rest.py
+++ b/plugins/modules/aci_rest.py
@@ -440,6 +440,7 @@ def main():
 
     aci.response_type(resp.read(), rest_type)
 
+    aci.result["status"] = aci.status
     aci.result["imdata"] = aci.imdata
     aci.result["totalCount"] = aci.totalCount
 


### PR DESCRIPTION
currently the aci_rest module only returns a status code of -1. Small fix to update the status with the correct response code