### PR TITLE
[ignore] example documentation fix

### DIFF
--- a/plugins/modules/aci_bd.py
+++ b/plugins/modules/aci_bd.py
@@ -55,7 +55,6 @@ options:
   endpoint_move_detect:
     description:
     - Determines if GARP should be enabled to detect when End Points move.
-    - The APIC defaults to C(garp) when unset during creation.
     type: str
     choices: [ default, garp ]
   endpoint_retention_action:

--- a/plugins/modules/aci_bd_to_l3out.py
+++ b/plugins/modules/aci_bd_to_l3out.py
@@ -54,8 +54,50 @@ author:
 - Jacob McGill (@jmcgill298)
 """
 
-# FIXME: Add examples
-EXAMPLES = r""" # """
+EXAMPLES = r"""
+- name: Bind Bridge Domain to L3 Out
+  cisco.aci.aci_bd_to_l3out:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    bd: web_servers
+    l3out: prod_l3out
+    tenant: prod
+    state: present
+  delegate_to: localhost
+
+- name: Unbind Bridge Domain from L3 Out
+  cisco.aci.aci_bd_to_l3out:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    bd: web_servers
+    l3out: prod_l3out
+    tenant: prod
+    state: absent
+  delegate_to: localhost
+
+- name: Query all Bridge Domains bound to L3 Outs
+  cisco.aci.aci_bd_to_l3out:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query specific Bridge Domain(s) bound to an L3 Out
+  cisco.aci.aci_bd_to_l3out:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    bd: web_servers
+    l3out: prod_l3out
+    tenant: prod
+    state: query
+  delegate_to: localhost
+  register: query_result
+"""
 
 RETURN = r"""
 current:

--- a/plugins/modules/aci_epg_monitoring_policy.py
+++ b/plugins/modules/aci_epg_monitoring_policy.py
@@ -59,17 +59,47 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
-EXAMPLES = r"""
-- cisco.aci.aci_epg_monitoring_policy:
-    host: '{{ hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    monitoring_policy: '{{ monitoring_policy }}'
-    description: '{{ description }}'
-    tenant: '{{ tenant }}'
+EXAMPLES = r'''
+- name: Create a monitoring policy
+  cisco.aci.aci_epg_monitoring_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    monitoring_policy: web_servers_monitoring
+    tenant: prod
+    state: present
   delegate_to: localhost
-"""
+
+- name: Delete a monitoring policy
+  cisco.aci.aci_epg_monitoring_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    monitoring_policy: web_servers_monitoring
+    tenant: prod
+    state: absent
+  delegate_to: localhost
+
+- name: Query all monitoring policy
+  cisco.aci.aci_epg_monitoring_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific monitoring policy
+  cisco.aci.aci_epg_monitoring_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    monitoring_policy: web_servers_monitoring
+    tenant: prod
+    state: query
+  delegate_to: localhost
+  register: query_result
+'''
 
 RETURN = r"""
 current:

--- a/plugins/modules/aci_epg_monitoring_policy.py
+++ b/plugins/modules/aci_epg_monitoring_policy.py
@@ -59,7 +59,7 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Create a monitoring policy
   cisco.aci.aci_epg_monitoring_policy:
     host: apic
@@ -99,7 +99,7 @@ EXAMPLES = r'''
     state: query
   delegate_to: localhost
   register: query_result
-'''
+"""
 
 RETURN = r"""
 current:

--- a/plugins/modules/aci_filter_entry.py
+++ b/plugins/modules/aci_filter_entry.py
@@ -115,20 +115,53 @@ author:
 - Jacob McGill (@jmcgill298)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- cisco.aci.aci_filter_entry:
-    host: "{{ inventory_hostname }}"
-    username: "{{ user }}"
-    password: "{{ pass }}"
-    state: "{{ state }}"
-    entry: "{{ entry }}"
-    tenant: "{{ tenant }}"
-    ether_name: "{{  ether_name }}"
-    icmp_msg_type: "{{ icmp_msg_type }}"
-    filter: "{{ filter }}"
-    descr: "{{ descr }}"
+- name: Create a filter entry
+  cisco.aci.aci_filter_entry:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    entry: https_allow
+    filter: web_filter
+    tenant: prod
+    ether_type: ip
+    ip_protocol: tcp
+    dst_port_start: 443
+    dst_port_end: 443
+    state: present
   delegate_to: localhost
+
+- name: Delete a filter entry
+  cisco.aci.aci_filter_entry:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    entry: https_allow
+    filter: web_filter
+    tenant: prod
+    state: absent
+  delegate_to: localhost
+
+- name: Query all filter entries
+  cisco.aci.aci_filter_entry:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific filter entry
+  cisco.aci.aci_filter_entry:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    entry: https_allow
+    filter: web_filter
+    tenant: prod
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_firmware_group.py
+++ b/plugins/modules/aci_firmware_group.py
@@ -47,18 +47,47 @@ author:
     - Steven Gerhart (@sgerhart)
 """
 
-# FIXME: Add more, better examples
+
 EXAMPLES = r"""
-    - name: firmware group
-      cisco.aci.aci_firmware_group:
-        host: "{{ inventory_hostname }}"
-        username: "{{ user }}"
-        password: "{{ pass }}"
-        validate_certs: no
-        group: testingfwgrp1
-        firmwarepol: test2FrmPol
-        state: present
+- name: Create a firmware group
+  cisco.aci.aci_firmware_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: fmgroup
+    firmwarepol: fmpolicy1
+    state: present
+  delegate_to: localhost
+
+- name: Delete a firmware group
+  cisco.aci.aci_firmware_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: fmgroup
+    state: absent
+  delegate_to: localhost
+
+- name: Query all firmware groups
+  cisco.aci.aci_firmware_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific firmware group
+  cisco.aci.aci_firmware_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: fmgroup
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
+
 RETURN = """
 current:
   description: The existing configuration from the APIC after the module has finished

--- a/plugins/modules/aci_firmware_group_node.py
+++ b/plugins/modules/aci_firmware_group_node.py
@@ -48,24 +48,45 @@ author:
 """
 
 EXAMPLES = r"""
-    - name: add firmware group node
-      cisco.aci.aci_firmware_group_node:
-        host: "{{ inventory_hostname }}"
-        username: "{{ user }}"
-        password: "{{ pass }}"
-        validate_certs: no
-        group: testingfwgrp
-        node: 1001
-        state: present
-    - name: Remove firmware group node
-      cisco.aci.aci_firmware_group_node:
-        host: "{{ inventory_hostname }}"
-        username: "{{ user }}"
-        password: "{{ pass }}"
-        validate_certs: no
-        group: testingfwgrp
-        node: 1001
-        state: absent
+- name: Add a firmware group node
+  cisco.aci.aci_firmware_group_node:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: fmgroup
+    node: 1001
+    state: present
+  delegate_to: localhost
+
+- name: Remove a firmware group node
+  cisco.aci.aci_firmware_group_node:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: fmgroup
+    node: 1001
+    state: absent
+  delegate_to: localhost
+
+- name: Query all firmware groups nodes
+  cisco.aci.aci_firmware_group_node:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific firmware group node
+  cisco.aci.aci_firmware_group_node:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: fmgroup
+    node: 1001
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = """

--- a/plugins/modules/aci_interface_policy_fc.py
+++ b/plugins/modules/aci_interface_policy_fc.py
@@ -56,18 +56,43 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Add a Fibre Channel interface policy
+- name: Create a Fibre Channel interface policy
   cisco.aci.aci_interface_policy_fc:
-    host: '{{ hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    fc_policy: '{{ fc_policy }}'
-    port_mode: '{{ port_mode }}'
-    description: '{{ description }}'
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    fc_policy: fcpolicy1
     state: present
   delegate_to: localhost
+
+- name: Delete a Fibre Channel interface policy
+  cisco.aci.aci_interface_policy_fc:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    fc_policy: fcpolicy1
+    state: absent
+  delegate_to: localhost
+
+- name: Query all Fibre Channel interface policies
+  cisco.aci.aci_interface_policy_fc:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific Fibre Channel interface policy
+  cisco.aci.aci_interface_policy_fc:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    fc_policy: fcpolicy1
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_interface_policy_l2.py
+++ b/plugins/modules/aci_interface_policy_l2.py
@@ -67,17 +67,43 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Add a Layer 2 interface policy
+- name: Create a Layer2 interface policy
   cisco.aci.aci_interface_policy_l2:
-    host: '{{ hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    l2_policy: '{{ l2_policy }}'
-    vlan_scope: '{{ vlan_policy }}'
-    description: '{{ description }}'
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    l2_policy: l2policy1
+    state: present
   delegate_to: localhost
+
+- name: Delete a Layer2 interface policy
+  cisco.aci.aci_interface_policy_l2:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    l2_policy: l2policy1
+    state: absent
+  delegate_to: localhost
+
+- name: Query all Layer2 interface policies
+  cisco.aci.aci_interface_policy_l2:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific Layer2 interface policy
+  cisco.aci.aci_interface_policy_l2:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    l2_policy: l2policy1
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_interface_policy_l2.py
+++ b/plugins/modules/aci_interface_policy_l2.py
@@ -73,7 +73,8 @@ EXAMPLES = r"""
     host: apic
     username: admin
     password: SomeSecretPassword
-    l2_policy: l2policy1
+    l2_policy: PORT_LOCAL
+    vlan_scope: portlocal
     state: present
   delegate_to: localhost
 
@@ -82,7 +83,7 @@ EXAMPLES = r"""
     host: apic
     username: admin
     password: SomeSecretPassword
-    l2_policy: l2policy1
+    l2_policy: PORT_LOCAL
     state: absent
   delegate_to: localhost
 
@@ -100,7 +101,7 @@ EXAMPLES = r"""
     host: apic
     username: admin
     password: SomeSecretPassword
-    l2_policy: l2policy1
+    l2_policy: PORT_LOCAL
     state: query
   delegate_to: localhost
   register: query_result

--- a/plugins/modules/aci_interface_policy_link_level.py
+++ b/plugins/modules/aci_interface_policy_link_level.py
@@ -75,7 +75,7 @@ author:
 
 EXAMPLES = r"""
 - name: Add a Link Level Policy
-  aci_interface_policy_link_level:
+  cisco.aci.aci_interface_policy_link_level:
     host: apic
     username: admin
     password: SomeSecretPassword
@@ -89,7 +89,7 @@ EXAMPLES = r"""
   delegate_to: localhost
 
 - name: Remove a Link Level Policy
-  aci_interface_policy_link_level:
+  cisco.aci.aci_interface_policy_link_level:
     host: apic
     username: admin
     password: SomeSecretPassword
@@ -97,7 +97,7 @@ EXAMPLES = r"""
     state: absent
 
 - name: Query a Link Level Policy
-  aci_interface_policy_link_level:
+  cisco.aci.aci_interface_policy_link_level:
     host: apic
     username: admin
     password: SomeSecretPassword
@@ -106,7 +106,7 @@ EXAMPLES = r"""
   delegate_to: localhost
 
 - name: Query all Link Level Policies
-  aci_interface_policy_link_level:
+  cisco.aci.aci_interface_policy_link_level:
     host: apic
     username: admin
     password: SomeSecretPassword

--- a/plugins/modules/aci_interface_policy_lldp.py
+++ b/plugins/modules/aci_interface_policy_lldp.py
@@ -66,7 +66,9 @@ EXAMPLES = r"""
     host: apic
     username: admin
     password: SomeSecretPassword
-    lldp_policy: lldppolicy1
+    lldp_policy: LLDP_OFF
+    receive_state: false
+    transmit_state: false
     state: present
   delegate_to: localhost
 
@@ -75,7 +77,7 @@ EXAMPLES = r"""
     host: apic
     username: admin
     password: SomeSecretPassword
-    lldp_policy: lldppolicy1
+    lldp_policy: LLDP_OFF
     state: absent
   delegate_to: localhost
 
@@ -93,7 +95,7 @@ EXAMPLES = r"""
     host: apic
     username: admin
     password: SomeSecretPassword
-    lldp_policy: lldppolicy1
+    lldp_policy: LLDP_OFF
     state: query
   delegate_to: localhost
   register: query_result

--- a/plugins/modules/aci_interface_policy_lldp.py
+++ b/plugins/modules/aci_interface_policy_lldp.py
@@ -60,18 +60,43 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Add a LLDP interface policy
+- name: Create a LLDP interface policy
   cisco.aci.aci_interface_policy_lldp:
-    host: '{{ hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    lldp_policy: '{{ lldp_policy }}'
-    description: '{{ description }}'
-    receive_state: '{{ receive_state }}'
-    transmit_state: '{{ transmit_state }}'
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    lldp_policy: lldppolicy1
+    state: present
   delegate_to: localhost
+
+- name: Delete a LLDP interface policy
+  cisco.aci.aci_interface_policy_lldp:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    lldp_policy: lldppolicy1
+    state: absent
+  delegate_to: localhost
+
+- name: Query all LLDP interface policies
+  cisco.aci.aci_interface_policy_lldp:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific LLDP interface policy
+  cisco.aci.aci_interface_policy_lldp:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    lldp_policy: lldppolicy1
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_interface_policy_mcp.py
+++ b/plugins/modules/aci_interface_policy_mcp.py
@@ -55,17 +55,44 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Add a MCP interface policy
+- name: Create a MCP interface policy
   cisco.aci.aci_interface_policy_mcp:
-    host: '{{ hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    mcp: '{{ mcp }}'
-    description: '{{ descr }}'
-    admin_state: '{{ admin_state }}'
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    mcp: MCP_OFF
+    admin_state: false
+    state: present
   delegate_to: localhost
+
+- name: Delete a MCP interface policy
+  cisco.aci.aci_interface_policy_mcp:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    mcp: MCP_OFF
+    state: absent
+  delegate_to: localhost
+
+- name: Query all MCP interface policies
+  cisco.aci.aci_interface_policy_mcp:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific MCP interface policy
+  cisco.aci.aci_interface_policy_mcp:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    mcp: MCP_OFF
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_interface_policy_port_channel.py
+++ b/plugins/modules/aci_interface_policy_port_channel.py
@@ -104,19 +104,46 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Add a port channel interface policy
+- name: Create a Port Channel interface policy
   cisco.aci.aci_interface_policy_port_channel:
-    host: '{{ inventory_hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    port_channel: '{{ port_channel }}'
-    description: '{{ description }}'
-    min_links: '{{ min_links }}'
-    max_links: '{{ max_links }}'
-    mode: '{{ mode }}'
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_channel: LACP_ACTIVE
+    mode: active
+    min_links: 1
+    max_links: 16
+    state: present
   delegate_to: localhost
+
+- name: Delete a Port Channel interface policy
+  cisco.aci.aci_interface_policy_port_channel:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_channel: LACP_ACTIVE
+    state: absent
+  delegate_to: localhost
+
+- name: Query all Port Channel interface policies
+  cisco.aci.aci_interface_policy_port_channel:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific Port Channel interface policy
+  cisco.aci.aci_interface_policy_port_channel:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_channel: LACP_ACTIVE
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_interface_policy_port_security.py
+++ b/plugins/modules/aci_interface_policy_port_security.py
@@ -62,18 +62,45 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Add a port security interface policy
+- name: Create a Port Security interface policy
   cisco.aci.aci_interface_policy_port_security:
-    host: '{{ inventory_hostname }}'
-    username: '{{ username }}'
-    password: '{{ password }}'
-    port_security: '{{ port_security }}'
-    description: '{{ descr }}'
-    max_end_points: '{{ max_end_points }}'
-    port_security_timeout: '{{ port_security_timeout }}'
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_security: PS_1
+    max_end_points: 1
+    port_security_timeout: 60
+    state: present
   delegate_to: localhost
+
+- name: Delete a Port Security interface policy
+  cisco.aci.aci_interface_policy_port_security:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_security: PS_1
+    state: absent
+  delegate_to: localhost
+
+- name: Query all Port Security interface policies
+  cisco.aci.aci_interface_policy_port_security:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific Port Security interface policy
+  cisco.aci.aci_interface_policy_port_security:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    port_security: PS_1
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_l2out_logical_interface_path.py
+++ b/plugins/modules/aci_l2out_logical_interface_path.py
@@ -86,29 +86,6 @@ author:
 """
 
 EXAMPLES = r"""
-- name: Add new node profile
-  cisco.aci.aci_l2out_logical_node_profile:
-    host: apic
-    username: admin
-    password: SomeSecretPassword
-    tenant: my_tenant
-    l2out: my_l2out
-    #node_profile: my_node_profile # 'default' by default
-    state: present
-  delegate_to: localhost
-
-- name: Add new interface profile
-  cisco.aci.aci_l2out_logical_interface_profile:
-    host: apic
-    username: admin
-    password: SomeSecretPassword
-    tenant: my_tenant
-    l2out: my_l2out
-    node_profile: default
-    interface_profile: my_interface_profile # 'default' by default
-    state: present
-  delegate_to: localhost
-
 - name: Add new path to interface profile
   cisco.aci.aci_l2out_logical_interface_path:
     host: apic
@@ -116,41 +93,47 @@ EXAMPLES = r"""
     password: SomeSecretPassword
     tenant: my_tenant
     l2out: my_l2out
-    node_profile: default
-    interface_profile: default
-    interface_type: vpc
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
     pod_id: 1
     leaves: 101-102
     interface: L2o1
     state: present
   delegate_to: localhost
 
-- name: Delete an interface profile
-  cisco.aci.aci_l2out_logical_interface_profile:
+- name: Delete path to interface profile
+  cisco.aci.aci_l2out_logical_interface_path:
     host: apic
     username: admin
     password: SomeSecretPassword
     tenant: my_tenant
     l2out: my_l2out
-    node_profile: default
-    interface_profile: default
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    pod_id: 1
+    leaves: 101-102
+    interface: L2o1
     state: absent
   delegate_to: localhost
 
-- name: Query an node profile
-  cisco.aci.aci_l2out_logical_node_profile:
+- name: Query a path to interface profile
+  cisco.aci.aci_l2out_logical_interface_path:
     host: apic
     username: admin
     password: SomeSecretPassword
     tenant: my_tenant
     l2out: my_l2out
-    #node_profile: default
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    pod_id: 1
+    leaves: 101-102
+    interface: L2o1
     state: query
   delegate_to: localhost
   register: query_result
 
-- name: Query all node profiles
-  cisco.aci.aci_l2out_logical_node_profile:
+- name: Query all paths to interface profiles
+  cisco.aci.aci_l2out_logical_interface_path:
     host: apic
     username: admin
     password: SomeSecretPassword

--- a/plugins/modules/aci_l2out_logical_interface_profile.py
+++ b/plugins/modules/aci_l2out_logical_interface_profile.py
@@ -62,7 +62,51 @@ author:
 """
 
 EXAMPLES = r"""
-See module aci_l2out_logical_interface_path.
+- name: Add new interface profile
+  cisco.aci.aci_l2out_logical_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l2out: my_l2out
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    state: present
+  delegate_to: localhost
+
+- name: Delete interface profile
+  cisco.aci.aci_l2out_logical_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l2out: my_l2out
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    state: absent
+  delegate_to: localhost
+
+- name: Query an interface profile
+  cisco.aci.aci_l2out_logical_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l2out: my_l2out
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all interface profiles
+  cisco.aci.aci_l2out_logical_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_l2out_logical_node_profile.py
+++ b/plugins/modules/aci_l2out_logical_node_profile.py
@@ -56,7 +56,48 @@ author:
 """
 
 EXAMPLES = r"""
-See module aci_l2out_logical_interface_path.
+- name: Add new node profile
+  cisco.aci.aci_l2out_logical_node_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l2out: my_l2out
+    node_profile: my_node_profile
+    state: present
+  delegate_to: localhost
+
+- name: Delete node profile
+  cisco.aci.aci_l2out_logical_node_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l2out: my_l2out
+    node_profile: my_node_profile
+    state: absent
+  delegate_to: localhost
+
+- name: Query an node profile
+  cisco.aci.aci_l2out_logical_node_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l2out: my_l2out
+    node_profile: my_node_profile
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all node profiles
+  cisco.aci.aci_l2out_logical_node_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_l3out_extepg.py
+++ b/plugins/modules/aci_l3out_extepg.py
@@ -92,7 +92,7 @@ EXAMPLES = r"""
   delegate_to: localhost
 
 - name: Delete ExtEpg
-  cisco.aci.aci_extepg:
+  cisco.aci.aci_l3out_extepg:
     host: apic
     username: admin
     password: SomeSecretPassword

--- a/plugins/modules/aci_l3out_route_tag_policy.py
+++ b/plugins/modules/aci_l3out_route_tag_policy.py
@@ -65,17 +65,47 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- cisco.aci.aci_l3out_route_tag_policy:
+- name: Create a l3out route tag policy
+  cisco.aci.aci_l3out_route_tag_policy:
     host: apic
     username: admin
     password: SomeSecretPassword
-    rtp: '{{ rtp_name }}'
+    tag: 1000
+    rtp: my_route_tag_policy
     tenant: production
-    tag: '{{ tag }}'
-    description: '{{ description }}'
+    state: present
   delegate_to: localhost
+
+- name: Delete a l3out route tag policy
+  cisco.aci.aci_l3out_route_tag_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    rtp: my_route_tag_policy
+    tenant: production
+    state: absent
+  delegate_to: localhost
+
+- name: Query all l3out route tag policies
+  cisco.aci.aci_l3out_route_tag_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific l3out route tag policy
+  cisco.aci.aci_l3out_route_tag_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    rtp: my_route_tag_policy
+    tenant: production
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_maintenance_group.py
+++ b/plugins/modules/aci_maintenance_group.py
@@ -45,17 +45,44 @@ author:
     - Steven Gerhart (@sgerhart)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: maintenance group
+- name: Create a maintenance group
   cisco.aci.aci_maintenance_group:
-    host: "{{ inventory_hostname }}"
-    username: "{{ user }}"
-    password: "{{ pass }}"
-    validate_certs: no
-    group: maintenancegrp1
-    policy: maintenancePol1
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: my_maintenance_group
+    policy: my_maintenance_policy
     state: present
+  delegate_to: localhost
+
+- name: Delete a maintenance group
+  cisco.aci.aci_maintenance_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: my_maintenance_group
+    state: absent
+  delegate_to: localhost
+
+- name: Query all maintenance groups
+  cisco.aci.aci_maintenance_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific maintenance group
+  cisco.aci.aci_maintenance_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: my_maintenance_group
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = """

--- a/plugins/modules/aci_maintenance_group_node.py
+++ b/plugins/modules/aci_maintenance_group_node.py
@@ -44,25 +44,45 @@ author:
 """
 
 EXAMPLES = r"""
-- name: maintenance group
+- name: Create a maintenance group node
   cisco.aci.aci_maintenance_group_node:
-    host: "{{ inventory_hostname }}"
-    username: "{{ user }}"
-    password: "{{ pass }}"
-    validate_certs: no
-    group: maintenancegrp1
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: my_maintenance_group
     node: 1001
     state: present
+  delegate_to: localhost
 
-- name: maintenance group
+- name: Delete a maintenance group node
   cisco.aci.aci_maintenance_group_node:
-    host: "{{ inventory_hostname }}"
-    username: "{{ user }}"
-    password: "{{ pass }}"
-    validate_certs: no
-    group: maintenancegrp1
-    node: 1002
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: my_maintenance_group
+    node: 1001
     state: absent
+  delegate_to: localhost
+
+- name: Query all maintenance group nodes
+  cisco.aci.aci_maintenance_group_node:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a maintenance group node
+  cisco.aci.aci_maintenance_group_node:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    group: my_maintenance_group
+    node: 1001
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_maintenance_policy.py
+++ b/plugins/modules/aci_maintenance_policy.py
@@ -68,18 +68,44 @@ author:
 - Steven Gerhart (@sgerhart)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- name: Ensure maintenance policy is present
+- name: Create a maintenance policy
   cisco.aci.aci_maintenance_policy:
-    host: '{{ inventory_hostname }}'
-    username: '{{ user }}'
-    password: '{{ pass }}'
-    validate_certs: no
-    name: maintenancePol1
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    name: my_maintenance_policy
     scheduler: simpleScheduler
-    runmode: False
     state: present
+  delegate_to: localhost
+
+- name: Delete a maintenance policy
+  cisco.aci.aci_maintenance_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    name: my_maintenance_policy
+    state: absent
+  delegate_to: localhost
+
+- name: Query all maintenance policies
+  cisco.aci.aci_maintenance_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific maintenance policy
+  cisco.aci.aci_maintenance_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    name: my_maintenance_policy
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_tenant_action_rule_profile.py
+++ b/plugins/modules/aci_tenant_action_rule_profile.py
@@ -58,16 +58,46 @@ author:
 - Dag Wieers (@dagwieers)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- cisco.aci.aci_tenant_action_rule_profile:
+- name: Create a action rule profile
+  cisco.aci.aci_tenant_action_rule_profile:
     host: apic
     username: admin
     password: SomeSecretPassword
-    action_rule: '{{ action_rule }}'
-    description: '{{ descr }}'
-    tenant: '{{ tenant }}'
+    action_rule: my_action_rule
+    tenant: prod
+    state: present
   delegate_to: localhost
+
+- name: Delete a action rule profile
+  cisco.aci.aci_tenant_action_rule_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    action_rule: my_action_rule
+    tenant: prod
+    state: absent
+  delegate_to: localhost
+
+- name: Query all action rule profiles
+  cisco.aci.aci_tenant_action_rule_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific action rule profile
+  cisco.aci.aci_tenant_action_rule_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    action_rule: my_action_rule
+    tenant: prod
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_tenant_span_src_group.py
+++ b/plugins/modules/aci_tenant_span_src_group.py
@@ -68,18 +68,46 @@ author:
 - Jacob McGill (@jmcgill298)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- cisco.aci.aci_tenant_span_src_group:
+- name: Create a SPAN source group
+  cisco.aci.aci_tenant_span_src_group:
     host: apic
     username: admin
     password: SomeSecretPassword
-    tenant: production
-    src_group: "{{ src_group }}"
-    dst_group: "{{ dst_group }}"
-    admin_state: "{{ admin_state }}"
-    description: "{{ description }}"
+    src_group: my_span_source_group
+    tenant: prod
+    state: present
   delegate_to: localhost
+
+- name: Delete a SPAN source group
+  cisco.aci.aci_tenant_span_src_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    src_group: my_span_source_group
+    tenant: prod
+    state: absent
+  delegate_to: localhost
+
+- name: Query all SPAN source groups
+  cisco.aci.aci_tenant_span_src_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific SPAN source group
+  cisco.aci.aci_tenant_span_src_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    src_group: my_span_source_group
+    tenant: prod
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_tenant_span_src_group_to_dst_group.py
+++ b/plugins/modules/aci_tenant_span_src_group_to_dst_group.py
@@ -64,17 +64,49 @@ author:
 - Jacob McGill (@jmcgill298)
 """
 
-# FIXME: Add more, better examples
 EXAMPLES = r"""
-- cisco.aci.aci_tenant_span_src_group_to_dst_group:
+- name: Bind SPAN source to destination group
+  cisco.aci.aci_tenant_span_src_group_to_dst_group:
     host: apic
     username: admin
     password: SomeSecretPassword
-    tenant: production
-    src_group: "{{ src_group }}"
-    dst_group: "{{ dst_group }}"
-    description: "{{ description }}"
+    src_group: my_span_source_group
+    dst_group: my_span_destination_group
+    tenant: prod
+    state: present
   delegate_to: localhost
+
+- name: Unbind SPAN source to destination group
+  cisco.aci.aci_tenant_span_src_group_to_dst_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    src_group: my_span_source_group
+    dst_group: my_span_destination_group
+    tenant: prod
+    state: absent
+  delegate_to: localhost
+
+- name: Query all SPAN source to destination group bindings
+  cisco.aci.aci_tenant_span_src_group_to_dst_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query a specific SPAN source to destination group binding
+  cisco.aci.aci_tenant_span_src_group_to_dst_group:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    src_group: my_span_source_group
+    dst_group: my_span_destination_group
+    tenant: prod
+    state: query
+  delegate_to: localhost
+  register: query_result
 """
 
 RETURN = r"""


### PR DESCRIPTION
fixes #299 

@lhercot these examples still miss proper examples, shall I work on these or separate issue?

plugins/modules/aci_bd_to_l3out.py
plugins/modules/aci_epg_monitoring_policy.py
plugins/modules/aci_filter_entry.py
plugins/modules/aci_firmware_group.py
plugins/modules/aci_firmware_group_node.py
plugins/modules/aci_interface_policy_fc.py
plugins/modules/aci_interface_policy_l2.py
plugins/modules/aci_interface_policy_lldp.py
plugins/modules/aci_interface_policy_mcp.py
plugins/modules/aci_interface_policy_port_channel.py
plugins/modules/aci_interface_policy_port_security.py
plugins/modules/aci_l2out_logical_interface_profile.py
plugins/modules/aci_l2out_logical_node_profile.py
plugins/modules/aci_l3out_route_tag_policy.py
plugins/modules/aci_maintenance_group.py
plugins/modules/aci_maintenance_group_node.py
plugins/modules/aci_maintenance_policy.py
plugins/modules/aci_tenant_action_rule_profile.py
plugins/modules/aci_tenant_span_src_group.py
plugins/modules/aci_tenant_span_src_group_to_dst_group.py