### PR TITLE
[minor_change] Add support for mpls custom qos policy for infra sr mp…

### DIFF
--- a/plugins/modules/aci_l3out_logical_node_profile.py
+++ b/plugins/modules/aci_l3out_logical_node_profile.py
@@ -46,7 +46,7 @@ options:
     aliases: [ target_dscp ]
   mpls_custom_qos_policy:
     description:
-    - The MPLS custom QOS policy name for the node profile.
+    - The MPLS custom QoS policy name for the node profile.
     - This argument should only be used for Infra SR-MPLS L3Outs.
     aliases: [ mpls_custom_qos_policy_name ]
     type: str

--- a/plugins/modules/aci_l3out_logical_node_profile.py
+++ b/plugins/modules/aci_l3out_logical_node_profile.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2023, Akini Ross (@akinross) <akinross@cisco.com>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -43,6 +44,12 @@ options:
     type: str
     choices: [ AF11, AF12, AF13, AF21, AF22, AF23, AF31, AF32, AF33, AF41, AF42, AF43, CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, EF, VA, unspecified ]
     aliases: [ target_dscp ]
+  mpls_custom_qos_policy:
+    description:
+    - The mpls custom QOS policy name for the node profile.
+    - This argument should only be used for Infra SR MPLS L3Outs.
+    aliases: [ mpls_custom_qos_policy_name ]
+    type: string
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -66,6 +73,7 @@ seealso:
   link: https://developer.cisco.com/docs/apic-mim-ref/
 author:
 - Jason Juenger (@jasonjuenger)
+- Akini Ross (@akinross)
 """
 
 EXAMPLES = r"""
@@ -79,6 +87,18 @@ EXAMPLES = r"""
     l3out: my_l3out
     tenant: my_tenant
     dscp: CS0
+    state: present
+  delegate_to: localhost
+
+- name: Add a new node profile with mpls custom qos policy to sr mpls infra l3out
+  cisco.aci.aci_l3out_logical_node_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: infra
+    l3out: infra_sr_mpls_l3out
+    node_profile: infra_sr_mpls_l3out_node_profile
+    mpls_custom_qos_policy: infra_mpls_custom_qos_policy
     state: present
   delegate_to: localhost
 
@@ -264,6 +284,8 @@ def main():
             ],
             aliases=["target_dscp"],
         ),
+        # alias=dict(type="str"), not implemented because of different (api/alias/mo/uni/) api endpoint
+        mpls_custom_qos_policy=dict(type="str", aliases=["mpls_custom_qos_policy_name"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
         name_alias=dict(type="str"),
     )
@@ -282,10 +304,15 @@ def main():
     l3out = module.params.get("l3out")
     description = module.params.get("description")
     dscp = module.params.get("dscp")
+    mpls_custom_qos_policy = module.params.get("mpls_custom_qos_policy")
     state = module.params.get("state")
     name_alias = module.params.get("name_alias")
 
     aci = ACIModule(module)
+
+    child_classes = []
+    if mpls_custom_qos_policy is not None:
+        child_classes.append("l3extRsLNodePMplsCustQosPol")
 
     aci.construct_url(
         root_class=dict(
@@ -306,11 +333,21 @@ def main():
             module_object=node_profile,
             target_filter={"name": node_profile},
         ),
+        child_classes=child_classes,
     )
 
     aci.get_existing()
 
     if state == "present":
+        child_configs = []
+        if mpls_custom_qos_policy is not None:
+            if mpls_custom_qos_policy == "":
+                child_configs.append(dict(l3extRsLNodePMplsCustQosPol=dict(attributes=dict(status="deleted"))))
+            else:
+                child_configs.append(
+                    dict(l3extRsLNodePMplsCustQosPol=dict(attributes=dict(tDn="uni/tn-infra/qosmplscustom-{0}".format(mpls_custom_qos_policy))))
+                )
+
         aci.payload(
             aci_class="l3extLNodeP",
             class_config=dict(
@@ -319,6 +356,7 @@ def main():
                 targetDscp=dscp,
                 nameAlias=name_alias,
             ),
+            child_configs=child_configs,
         )
 
         aci.get_diff(aci_class="l3extLNodeP")

--- a/plugins/modules/aci_l3out_logical_node_profile.py
+++ b/plugins/modules/aci_l3out_logical_node_profile.py
@@ -49,7 +49,7 @@ options:
     - The MPLS custom QOS policy name for the node profile.
     - This argument should only be used for Infra SR-MPLS L3Outs.
     aliases: [ mpls_custom_qos_policy_name ]
-    type: string
+    type: str
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.

--- a/plugins/modules/aci_l3out_logical_node_profile.py
+++ b/plugins/modules/aci_l3out_logical_node_profile.py
@@ -46,8 +46,8 @@ options:
     aliases: [ target_dscp ]
   mpls_custom_qos_policy:
     description:
-    - The mpls custom QOS policy name for the node profile.
-    - This argument should only be used for Infra SR MPLS L3Outs.
+    - The MPLS custom QOS policy name for the node profile.
+    - This argument should only be used for Infra SR-MPLS L3Outs.
     aliases: [ mpls_custom_qos_policy_name ]
     type: string
   state:
@@ -90,7 +90,7 @@ EXAMPLES = r"""
     state: present
   delegate_to: localhost
 
-- name: Add a new node profile with mpls custom qos policy to sr mpls infra l3out
+- name: Add a new node profile with MPLS custom QOS policy to SR-MPLS infra l3out
   cisco.aci.aci_l3out_logical_node_profile:
     host: apic
     username: admin

--- a/tests/integration/targets/aci_l3out_bgp_peer/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_bgp_peer/tasks/main.yml
@@ -1557,6 +1557,7 @@
         mpls: yes
         domain: ansible_domain
         route_control: export
+        l3protocol: bgp
         state: present
 
     - name: Create l3out logical node profile in infra tenant

--- a/tests/integration/targets/aci_l3out_logical_node_profile/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_logical_node_profile/tasks/main.yml
@@ -133,7 +133,7 @@
     - version.current.0.topSystem.attributes.version is version('5', '>=')  # This condition will execute only for APIC version 5.x and above
     block: 
 
-    - name: Ensure infra sr mpls l3out does not exist
+    - name: Ensure infra SR-MPLS l3out does not exist
       cisco.aci.aci_l3out: &aci_infra_sr_mpls_l3out_absent
         <<: *aci_info
         tenant: infra
@@ -143,12 +143,12 @@
         mpls: "yes"
         state: absent
 
-    - name: Add a infra sr mpls l3out 
+    - name: Add a infra SR-MPLS l3out 
       cisco.aci.aci_l3out:
         <<: *aci_infra_sr_mpls_l3out_absent
         state: present
 
-    - name: Add a node profile with mpls custom qos policy 
+    - name: Add a node profile with MPLS custom QOS policy 
       cisco.aci.aci_l3out_logical_node_profile: &aci_infra_node_profile_qos
         <<: *aci_info
         tenant: infra
@@ -157,24 +157,24 @@
         mpls_custom_qos_policy: ansible_test_mpls_custom_qos_policy
       register: nm_add_node_profile_qos
 
-    - name: Modify mpls custom qos policy to node profile
+    - name: Modify MPLS custom QOS policy to node profile
       cisco.aci.aci_l3out_logical_node_profile: &aci_infra_node_profile_qos_changed
         <<: *aci_infra_node_profile_qos
         mpls_custom_qos_policy: ansible_test_mpls_custom_qos_policy_changed
       register: nm_mod_node_profile_qos_changed
 
-    - name: Modify mpls custom qos policy to node profile again
+    - name: Modify MPLS custom QOS policy to node profile again
       cisco.aci.aci_l3out_logical_node_profile: 
         <<: *aci_infra_node_profile_qos_changed
       register: nm_mod_node_profile_qos_again
 
-    - name: Remove mpls custom qos policy from node profile again
+    - name: Remove MPLS custom QOS policy from node profile again
       cisco.aci.aci_l3out_logical_node_profile: 
         <<: *aci_infra_node_profile_qos_changed
         mpls_custom_qos_policy: ""
       register: nm_del_node_profile_qos
 
-    - name: Verify mpls custom qos policy configuration on node profile
+    - name: Verify MPLS custom QOS policy configuration on node profile
       assert:
         that:
         - nm_add_node_profile_qos is changed
@@ -190,7 +190,7 @@
         - nm_del_node_profile_qos.previous.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy_changed"
         - nm_del_node_profile_qos.current.0.l3extLNodeP.children is undefined
 
-    - name: Remove a infra sr mpls l3out 
+    - name: Remove a infra SR-MPLS l3out 
       cisco.aci.aci_l3out:
         <<: *aci_infra_sr_mpls_l3out_absent
 

--- a/tests/integration/targets/aci_l3out_logical_node_profile/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_logical_node_profile/tasks/main.yml
@@ -1,5 +1,6 @@
 # Test code for the ACI modules
 # Copyright: (c) 2021, Jason Juenger (@jasonjuenger)
+# Copyright: (c) 2023, Akini Ross (@akinross) <akinross@cisco.com>
 
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -18,6 +19,13 @@
       use_ssl: '{{ aci_use_ssl | default(true) }}'
       use_proxy: '{{ aci_use_proxy | default(true) }}'
       output_level: info
+
+- name: Query system information
+  cisco.aci.aci_system:
+    <<: *aci_info
+    id: 1
+    state: query
+  register: version
 
 # CLEAN ENVIRONMENT
 - name: Remove the ansible_tenant
@@ -119,6 +127,72 @@
       - cm_mod_node_profile.proposed.l3extLNodeP.attributes.descr == nm_mod_node_profile.proposed.l3extLNodeP.attributes.descr == 'my_updated_descr'
       - nm_mod_node_profile.current.0.l3extLNodeP.attributes.dn == 'uni/tn-ansible_tenant/out-ansible_l3out/lnodep-ansible_node_profile'
       - nm_mod_node_profile.current.0.l3extLNodeP.attributes.name == 'ansible_node_profile'
+
+  - name: Execute tasks only for APIC version 5.x and above
+    when:
+    - version.current.0.topSystem.attributes.version is version('5', '>=')  # This condition will execute only for APIC version 5.x and above
+    block: 
+
+    - name: Ensure infra sr mpls l3out does not exist
+      cisco.aci.aci_l3out: &aci_infra_sr_mpls_l3out_absent
+        <<: *aci_info
+        tenant: infra
+        name: ansible_infra_sr_mpls_l3out
+        domain: ansible_dom
+        vrf: overlay-1
+        mpls: "yes"
+        state: absent
+
+    - name: Add a infra sr mpls l3out 
+      cisco.aci.aci_l3out:
+        <<: *aci_infra_sr_mpls_l3out_absent
+        state: present
+
+    - name: Add a node profile with mpls custom qos policy 
+      cisco.aci.aci_l3out_logical_node_profile: &aci_infra_node_profile_qos
+        <<: *aci_info
+        tenant: infra
+        l3out: ansible_infra_sr_mpls_l3out
+        node_profile: ansible_infra_sr_mpls_l3out_node_profile
+        mpls_custom_qos_policy: ansible_test_mpls_custom_qos_policy
+      register: nm_add_node_profile_qos
+
+    - name: Modify mpls custom qos policy to node profile
+      cisco.aci.aci_l3out_logical_node_profile: &aci_infra_node_profile_qos_changed
+        <<: *aci_infra_node_profile_qos
+        mpls_custom_qos_policy: ansible_test_mpls_custom_qos_policy_changed
+      register: nm_mod_node_profile_qos_changed
+
+    - name: Modify mpls custom qos policy to node profile again
+      cisco.aci.aci_l3out_logical_node_profile: 
+        <<: *aci_infra_node_profile_qos_changed
+      register: nm_mod_node_profile_qos_again
+
+    - name: Remove mpls custom qos policy from node profile again
+      cisco.aci.aci_l3out_logical_node_profile: 
+        <<: *aci_infra_node_profile_qos_changed
+        mpls_custom_qos_policy: ""
+      register: nm_del_node_profile_qos
+
+    - name: Verify mpls custom qos policy configuration on node profile
+      assert:
+        that:
+        - nm_add_node_profile_qos is changed
+        - nm_add_node_profile_qos.previous == []
+        - nm_add_node_profile_qos.current.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy"
+        - nm_mod_node_profile_qos_changed is changed
+        - nm_mod_node_profile_qos_changed.previous.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy"
+        - nm_mod_node_profile_qos_changed.current.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy_changed"
+        - nm_mod_node_profile_qos_again is not changed
+        - nm_mod_node_profile_qos_again.previous.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy_changed"
+        - nm_mod_node_profile_qos_again.current.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy_changed"
+        - nm_del_node_profile_qos is changed
+        - nm_del_node_profile_qos.previous.0.l3extLNodeP.children.0.l3extRsLNodePMplsCustQosPol.attributes.tDn == "uni/tn-infra/qosmplscustom-ansible_test_mpls_custom_qos_policy_changed"
+        - nm_del_node_profile_qos.current.0.l3extLNodeP.children is undefined
+
+    - name: Remove a infra sr mpls l3out 
+      cisco.aci.aci_l3out:
+        <<: *aci_infra_sr_mpls_l3out_absent
 
   - name: Query existing node profile (check mode)
     cisco.aci.aci_l3out_logical_node_profile: &query_existing_node_profile

--- a/tests/integration/targets/aci_l3out_logical_node_profile/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_logical_node_profile/tasks/main.yml
@@ -141,6 +141,7 @@
         domain: ansible_dom
         vrf: overlay-1
         mpls: "yes"
+        l3protocol: bgp
         state: absent
 
     - name: Add a infra SR-MPLS l3out 
@@ -148,7 +149,7 @@
         <<: *aci_infra_sr_mpls_l3out_absent
         state: present
 
-    - name: Add a node profile with MPLS custom QOS policy 
+    - name: Add a node profile with MPLS custom QoS policy 
       cisco.aci.aci_l3out_logical_node_profile: &aci_infra_node_profile_qos
         <<: *aci_info
         tenant: infra
@@ -157,24 +158,24 @@
         mpls_custom_qos_policy: ansible_test_mpls_custom_qos_policy
       register: nm_add_node_profile_qos
 
-    - name: Modify MPLS custom QOS policy to node profile
+    - name: Modify MPLS custom QoS policy to node profile
       cisco.aci.aci_l3out_logical_node_profile: &aci_infra_node_profile_qos_changed
         <<: *aci_infra_node_profile_qos
         mpls_custom_qos_policy: ansible_test_mpls_custom_qos_policy_changed
       register: nm_mod_node_profile_qos_changed
 
-    - name: Modify MPLS custom QOS policy to node profile again
+    - name: Modify MPLS custom QoS policy to node profile again
       cisco.aci.aci_l3out_logical_node_profile: 
         <<: *aci_infra_node_profile_qos_changed
       register: nm_mod_node_profile_qos_again
 
-    - name: Remove MPLS custom QOS policy from node profile again
+    - name: Remove MPLS custom QoS policy from node profile again
       cisco.aci.aci_l3out_logical_node_profile: 
         <<: *aci_infra_node_profile_qos_changed
         mpls_custom_qos_policy: ""
       register: nm_del_node_profile_qos
 
-    - name: Verify MPLS custom QOS policy configuration on node profile
+    - name: Verify MPLS custom QoS policy configuration on node profile
       assert:
         that:
         - nm_add_node_profile_qos is changed


### PR DESCRIPTION
…ls l3outs node profiles in aci_l3out_logical_node_profile

aci_l3out_logical_node_profile part of #125 

This PR is depending on #542 and should be merged after. Cherry pick the commit in case you want to run tests.