### PR TITLE
Add DHCP Relay configurations for L3Out Logical Interface Profile.

### DIFF
--- a/plugins/modules/aci_dhcp_option.py
+++ b/plugins/modules/aci_dhcp_option.py
@@ -1,0 +1,306 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: aci_dhcp_option
+short_description: Manage DHCP Option (dhcp:Option)
+description:
+- Manage DHCP Options for DHCP Option Policies on Cisco ACI fabrics.
+- The DHCP option is used to supply DHCP clients with configuration parameters such as a domain, name server, subnet, and network address.
+  DHCP provides a framework for passing configuration information to clients on a TCP/IP network.
+  The configuration parameters, and other control information, are carried in tagged data items that are stored in the options field of a DHCP message.
+  The data items themselves are also called options. You can view, set, unset, and edit DHCP option values.
+  When you set an option value, the DHCP server replaces any existing value or creates a new one as needed for the given option name.
+options:
+  tenant:
+    description:
+    - The name of an existing tenant.
+    type: str
+    aliases: [ tenant_name ]
+  dhcp_option_policy:
+    description:
+    - The name of an existing DHCP Option Policy.
+    type: str
+    aliases: [ dhcp_option_policy_name ]
+  dhcp_option:
+    description:
+    - The name of the DHCP Option.
+    type: str
+    aliases: [ dhcp_option_name, name ]
+  data:
+    description:
+    - The value of the DHCP Option.
+    type: str
+  id:
+    description:
+    - The DHCP Option ID.
+    type: int
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment:
+- cisco.aci.aci
+- cisco.aci.annotation
+- cisco.aci.owner
+
+notes:
+- The C(tenant) must exist before using this module in your playbook.
+  The M(cisco.aci.aci_tenant) can be used for this.
+seealso:
+- module: cisco.aci.aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Gaspard Micol (@gmicol)
+"""
+
+EXAMPLES = r"""
+- name: Add a new DHCP Option
+  cisco.aci.aci_dhcp_option:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    dhcp_option: my_dhcp_option
+    id: 1
+    data: 82
+    state: present
+  delegate_to: localhost
+
+- name: Delete an DHCP Option
+  cisco.aci.aci_dhcp_option:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    dhcp_option: my_dhcp_option
+    state: absent
+  delegate_to: localhost
+
+- name: Query a DHCP Option
+  cisco.aci.aci_dhcp_option:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    dhcp_option: my_dhcp_option
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all DHCP Options in my_dhcp_option_policy
+  cisco.aci.aci_dhcp_option:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    state: query
+  delegate_to: localhost
+  register: query_result
+"""
+
+RETURN = r"""
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec, aci_owner_spec
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(aci_annotation_spec())
+    argument_spec.update(aci_owner_spec())
+    argument_spec.update(
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        dhcp_option_policy=dict(type="str", aliases=["dhcp_option_policy_name"]),
+        dhcp_option=dict(type="str", aliases=["dhcp_option_name", "name"]),
+        data=dict(type="str"),
+        id=dict(type="int"),
+        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ["state", "absent", ["tenant", "dhcp_option_policy", "dhcp_option"]],
+            ["state", "present", ["tenant", "dhcp_option_policy", "dhcp_option"]],
+        ],
+    )
+
+    tenant = module.params.get("tenant")
+    dhcp_option_policy = module.params.get("dhcp_option_policy")
+    dhcp_option = module.params.get("dhcp_option")
+    data = module.params.get("data")
+    id = module.params.get("id")
+    state = module.params.get("state")
+
+    aci = ACIModule(module)
+
+    aci.construct_url(
+        root_class=dict(
+            aci_class="fvTenant",
+            aci_rn="tn-{0}".format(tenant),
+            module_object=tenant,
+            target_filter={"name": tenant},
+        ),
+        subclass_1=dict(
+            aci_class="dhcpOption",
+            aci_rn="dhcpoptpol-{0}".format(dhcp_option_policy),
+            module_object=dhcp_option_policy,
+            target_filter={"name": dhcp_option_policy},
+        ),
+        subclass_2=dict(
+            aci_class="dhcpOption",
+            aci_rn="opt-{0}".format(dhcp_option),
+            module_object=dhcp_option,
+            target_filter={"name": dhcp_option},
+        ),
+    )
+
+    aci.get_existing()
+
+    if state == "present":
+        aci.payload(
+            aci_class="dhcpOption",
+            class_config=dict(
+                name=dhcp_option,
+                data=data,
+                id=id,
+            ),
+        )
+
+        aci.get_diff(aci_class="dhcpOption")
+
+        aci.post_config()
+
+    elif state == "absent":
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aci_dhcp_option.py
+++ b/plugins/modules/aci_dhcp_option.py
@@ -267,7 +267,7 @@ def main():
             target_filter={"name": tenant},
         ),
         subclass_1=dict(
-            aci_class="dhcpOption",
+            aci_class="dhcpOptionPol",
             aci_rn="dhcpoptpol-{0}".format(dhcp_option_policy),
             module_object=dhcp_option_policy,
             target_filter={"name": dhcp_option_policy},

--- a/plugins/modules/aci_dhcp_option_policy.py
+++ b/plugins/modules/aci_dhcp_option_policy.py
@@ -1,0 +1,276 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: aci_dhcp_option_policy
+short_description: Manage DHCP Option Policy (dhcp:OptionPol)
+description:
+- Manage DHCP Option Policy for tenants on Cisco ACI fabrics.
+options:
+  tenant:
+    description:
+    - The name of an existing tenant.
+    type: str
+    aliases: [ tenant_name ]
+  dhcp_option_policy:
+    description:
+    - The name of the DHCP Option Policy.
+    type: str
+    aliases: [ dhcp_option_policy_name, name ]
+  description:
+    description:
+    - The description for the DHCP Option Policy.
+    type: str
+    aliases: [ descr ]
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment:
+- cisco.aci.aci
+- cisco.aci.annotation
+- cisco.aci.owner
+
+notes:
+- The C(tenant) must exist before using this module in your playbook.
+  The M(cisco.aci.aci_tenant) can be used for this.
+seealso:
+- module: cisco.aci.aci_tenant
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Gaspard Micol (@gmicol)
+"""
+
+EXAMPLES = r"""
+- name: Add a new DHCP Option Policy
+  cisco.aci.aci_dhcp_option_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    state: present
+  delegate_to: localhost
+
+- name: Delete an DHCP Option Policy
+  cisco.aci.aci_dhcp_option_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    state: absent
+  delegate_to: localhost
+
+- name: Query a DHCP Option Policy
+  cisco.aci.aci_dhcp_option_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all DHCP Option Policies in my_tenant
+  cisco.aci.aci_dhcp_option_policy:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    state: query
+  delegate_to: localhost
+  register: query_result
+"""
+
+RETURN = r"""
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec, aci_owner_spec
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(aci_annotation_spec())
+    argument_spec.update(aci_owner_spec())
+    argument_spec.update(
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        dhcp_option_policy=dict(type="str", aliases=["dhcp_option_policy_name", "name"]),
+        description=dict(type="str", aliases=["descr"]),
+        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ["state", "absent", ["tenant", "dhcp_option_policy"]],
+            ["state", "present", ["tenant", "dhcp_option_policy"]],
+        ],
+    )
+
+    tenant = module.params.get("tenant")
+    description = module.params.get("description")
+    dhcp_option_policy = module.params.get("dhcp_option_policy")
+    state = module.params.get("state")
+
+    aci = ACIModule(module)
+
+    aci.construct_url(
+        root_class=dict(
+            aci_class="fvTenant",
+            aci_rn="tn-{0}".format(tenant),
+            module_object=tenant,
+            target_filter={"name": tenant},
+        ),
+        subclass_1=dict(
+            aci_class="dhcpOptionPol",
+            aci_rn="dhcpoptpol-{0}".format(dhcp_option_policy),
+            module_object=dhcp_option_policy,
+            target_filter={"name": dhcp_option_policy},
+        ),
+    )
+
+    aci.get_existing()
+
+    if state == "present":
+        aci.payload(
+            aci_class="dhcpOptionPol",
+            class_config=dict(
+                name=dhcp_option_policy,
+                descr=description,
+            ),
+        )
+
+        aci.get_diff(aci_class="dhcpOptionPol")
+
+        aci.post_config()
+
+    elif state == "absent":
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aci_l3out_dhcp_relay_label.py
+++ b/plugins/modules/aci_l3out_dhcp_relay_label.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+DOCUMENTATION = r"""
+---
+module: aci_l3out_dhcp_relay_label
+short_description: Manage Layer 3 Outside (L3Out) DHCP Relay Label (dhcp:Lbl)
+description:
+- Manage DHCP Relay Labels for L3Out Logical Interface Profiles on Cisco ACI fabrics.
+- A DHCP Relay Label contains the name of an existing DHCP Relay Policy for the label,
+  the scope, and a DHCP Option Policy.
+options:
+  tenant:
+    description:
+    - The name of an existing tenant.
+    type: str
+    aliases: [ tenant_name ]
+  l3out:
+    description:
+    - The name of an existing L3Out.
+    type: str
+    aliases: [ l3out_name ]
+  node_profile:
+    description:
+    - The name of an existing node profile.
+    type: str
+    aliases: [ node_profile_name, logical_node ]
+  interface_profile:
+    description:
+    - The name of an existing interface profile.
+    type: str
+    aliases: [ interface_profile_name, logical_interface ]
+  dhcp_relay_label:
+    description:
+    - The name/label of an existing DHCP Relay Policy.
+    type: str
+    aliases: [ name, relay_policy ]
+  scope:
+    description:
+    - The scope is the owner of the relay server.
+    - The APIC defaults to C(infra) when unset during creation.
+    type: str
+    choices: [ infra, tenant ]
+    aliases: [ owner ]
+  dhcp_option_policy:
+    description:
+    - The name of an existing DHCP Option Policy to be associated with the DCHP Relay Policy.
+    - the DHCP option policy supplies DHCP clients with configuration parameters
+      such as domain, nameserver, and subnet router addresses.
+    type: str
+    aliases: [ dhcp_option_policy_name ]
+  description:
+    description:
+    - The description of the DHCP Relay Label.
+    type: str
+    aliases: [ descr ]
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment:
+- cisco.aci.aci
+- cisco.aci.annotation
+- cisco.aci.owner
+
+notes:
+- The C(tenant), C(l3out), C(node_profile), C(interface_profile) and C(relay_policy) must exist before using this module in your playbook.
+  The M(cisco.aci.aci_tenant), M(cisco.aci.aci_l3out), M(cisco.aci.aci_l3out_logical_node_profile), M(cisco.aci.aci_l3out_logical_interface_profile)
+  and M(cisco.aci.aci_dhcp_relay) can be used for this.
+- If C(dhcp_option_policy) is used, it must exist before using this module in your playbook.
+  The M(cisco.aci.aci_dhcp_option_policy) can be used for this.
+seealso:
+- module: cisco.aci.aci_tenant
+- module: cisco.aci.aci_l3out
+- module: cisco.aci.aci_l3out_logical_node_profile
+- module: cisco.aci.aci_l3out_logical_interface_profile
+- module: cisco.aci.aci_dhcp_relay
+- module: cisco.aci.aci_dhcp_option_policy
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Gaspard Micol (@gmicol)
+"""
+
+EXAMPLES = r"""
+- name: Add a new L3Out DHCP Relay Label
+  cisco.aci.aci_l3out_eigrp_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l3out: my_l3out
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    dhcp_relay_label: my_dhcp_relay_label
+    scope: tenant
+    dhcp_option_policy: my_dhcp_option_policy
+    state: present
+  delegate_to: localhost
+
+- name: Delete an L3Out DHCP Relay Label
+  cisco.aci.aci_l3out_eigrp_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l3out: my_l3out
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    dhcp_relay_label: my_dhcp_relay_label
+    state: absent
+  delegate_to: localhost
+
+- name: Query an L3Out DHCP Relay Label
+  cisco.aci.aci_l3out_eigrp_interface_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    l3out: my_l3out
+    node_profile: my_node_profile
+    interface_profile: my_interface_profile
+    dhcp_relay_label: my_dhcp_relay_label
+    state: query
+  delegate_to: localhost
+  register: query_result
+"""
+
+RETURN = r"""
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec, aci_owner_spec
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(aci_annotation_spec())
+    argument_spec.update(aci_owner_spec())
+    argument_spec.update(
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"]),
+        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"]),
+        dhcp_relay_label=dict(type="str", aliases=["name", "relay_policy"]),
+        scope=dict(type="str", choices=["infra", "tenant"], aliases=["owner"]),
+        dhcp_option_policy=dict(type="str", aliases=["dhcp_option_policy_name"]),
+        description=dict(type="str", aliases=["descr"]),
+        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "dhcp_relay_label"]],
+            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "dhcp_relay_label"]],
+        ],
+    )
+
+    tenant = module.params.get("tenant")
+    l3out = module.params.get("l3out")
+    node_profile = module.params.get("node_profile")
+    interface_profile = module.params.get("interface_profile")
+    dhcp_relay_label = module.params.get("dhcp_relay_label")
+    scope = module.params.get("scope")
+    dhcp_option_policy = module.params.get("dhcp_option_policy")
+    description = module.params.get("description")
+    state = module.params.get("state")
+
+    aci = ACIModule(module)
+
+    child_classes = ["dhcpRsDhcpOptionPol"]
+
+    aci.construct_url(
+        root_class=dict(
+            aci_class="fvTenant",
+            aci_rn="tn-{0}".format(tenant),
+            module_object=tenant,
+            target_filter={"name": tenant},
+        ),
+        subclass_1=dict(
+            aci_class="l3extOut",
+            aci_rn="out-{0}".format(l3out),
+            module_object=l3out,
+            target_filter={"name": l3out},
+        ),
+        subclass_2=dict(
+            aci_class="l3extLNodeP",
+            aci_rn="lnodep-{0}".format(node_profile),
+            module_object=node_profile,
+            target_filter={"name": node_profile},
+        ),
+        subclass_3=dict(
+            aci_class="l3extLIfP",
+            aci_rn="lifp-[{0}]".format(interface_profile),
+            module_object=interface_profile,
+            target_filter={"name": interface_profile},
+        ),
+        subclass_4=dict(
+            aci_class="dhcpLbl",
+            aci_rn="dhcplbl-[{0}]".format(dhcp_relay_label),
+            module_object=dhcp_relay_label,
+            target_filter={"name": dhcp_relay_label},
+        ),
+        child_classes=child_classes,
+    )
+
+    aci.get_existing()
+
+    if state == "present":
+        child_configs = [dict(dhcpRsDhcpOptionPol=dict(attributes=dict(tnDhcpOptionPolName=dhcp_option_policy)))]
+
+        aci.payload(
+            aci_class="dhcpLbl",
+            class_config=dict(
+                descr=description,
+                name=dhcp_relay_label,
+                owner=scope,
+            ),
+            child_configs=child_configs,
+        )
+
+        aci.get_diff(aci_class="dhcpLbl")
+
+        aci.post_config()
+
+    elif state == "absent":
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aci_l3out_dhcp_relay_label.py
+++ b/plugins/modules/aci_l3out_dhcp_relay_label.py
@@ -54,8 +54,11 @@ options:
   dhcp_option_policy:
     description:
     - The name of an existing DHCP Option Policy to be associated with the DCHP Relay Policy.
-    - the DHCP option policy supplies DHCP clients with configuration parameters
+    - The DHCP option policy supplies DHCP clients with configuration parameters
       such as domain, nameserver, and subnet router addresses.
+    - Passing an empty string will delete the current linked DHCP Option Policy.
+      However, this will associate the DHCP Relay Label to the default DHCP Option Policy
+      from the common Tenant.
     type: str
     aliases: [ dhcp_option_policy_name ]
   description:

--- a/tests/integration/targets/aci_dhcp_option/aliases
+++ b/tests/integration/targets/aci_dhcp_option/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/aci_dhcp_option/tasks/main.yml
@@ -121,10 +121,41 @@
         - query_ansible_dhcp_option_1.current.0.dhcpOption.attributes.id == "1"
         - query_ansible_dhcp_option_1.current.0.dhcpOption.attributes.data == "82"
 
+  #UPDATING DHCP OPTION
+  - name: Update first DHCP option (check_mode)
+    cisco.aci.aci_dhcp_option: &aci_dhcp_option_update
+      <<: *aci_dhcp_option_present
+      id: 3
+      data: 255
+      state: present
+    check_mode: true
+    register: cm_update_dhcp_option
+
+  - name: Update first DHCP option (normal_mode)
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_dhcp_option_update
+    register: nm_update_dhcp_option
+
+  - name: Update first DHCP option again - testing idempotency
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_dhcp_option_update
+    register: nm_update_dhcp_option_idempotency
+
+  - name: Asserts for DHCP option update tasks
+    ansible.builtin.assert:
+      that:
+        - cm_update_dhcp_option is changed
+        - cm_update_dhcp_option.previous == cm_update_dhcp_option.current
+        - nm_update_dhcp_option is changed
+        - nm_update_dhcp_option.current.0.dhcpOption.attributes.name == "ansible_dhcp_option_1"
+        - nm_update_dhcp_option.current.0.dhcpOption.attributes.id == "3"
+        - nm_update_dhcp_option.current.0.dhcpOption.attributes.data == "255"
+        - nm_update_dhcp_option_idempotency is not changed
+
   # DELETE DHCP OPTION
   - name: Remove DHCP option (check_mode)
     cisco.aci.aci_dhcp_option: &dhcp_option_absent
-      <<: *aci_dhcp_option_present
+      <<: *aci_dhcp_option_update
       state: absent
     check_mode: true
     register: cm_remove_dhcp_option

--- a/tests/integration/targets/aci_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/aci_dhcp_option/tasks/main.yml
@@ -1,0 +1,157 @@
+# Test code for the ACI modules
+# Copyright: (c) 2023, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: debug
+
+# CLEAN ENVIRONMENT BEFORE TESTS
+- name: Remove the ansible_tenant
+  cisco.aci.aci_tenant: &aci_tenant_absent
+    <<: *aci_info 
+    tenant: ansible_tenant
+    state: absent
+
+- name: Verify Cloud and Non-Cloud Sites in use.
+  ansible.builtin.include_tasks: ../../../../../../integration/targets/aci_cloud_provider/tasks/main.yml
+
+- name: Execute tasks only for non-cloud sites
+  when: query_cloud.current == []  # This condition will execute only non-cloud sites
+  block:  # block specifies execution of tasks within, based on conditions
+  - name: Add a new tenant
+    cisco.aci.aci_tenant: &aci_tenant_present
+      <<: *aci_info
+      tenant: ansible_tenant
+      description: Ansible tenant
+      state: present
+
+  - name: Add a new DHCP option policy
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_info
+      tenant: ansible_tenant
+      dhcp_option_policy: ansible_dhcp_option_policy_1
+      description: DHCP option policy 1 for ansible_tenant tenant
+      state: present
+  
+  # CREATE DHCP OPTION
+  - name: Add a DHCP option (check_mode)
+    cisco.aci.aci_dhcp_option: &aci_dhcp_option_present
+      <<: *aci_info
+      tenant: ansible_tenant
+      dhcp_option_policy: ansible_dhcp_option_policy_1
+      dhcp_option: ansible_dhcp_option_1
+      id: 1
+      data: 82
+      state: present
+    check_mode: true
+    register: cm_add_dhcp_option
+
+  - name: Add a DHCP option (normal_mode)
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_dhcp_option_present
+    register: nm_add_dhcp_option
+
+  - name: Add the first DHCP option again - testing idempotency
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_dhcp_option_present
+    register: nm_add_dhcp_option_idempotency
+
+  - name: Add a second DHCP option (normal_mode)
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_info
+      tenant: ansible_tenant
+      dhcp_option_policy: ansible_dhcp_option_policy_1
+      dhcp_option: ansible_dhcp_option_2
+      id: 2
+      data: 252
+      state: present
+    register: nm_add_dhcp_option_2
+
+  - name: Asserts for DHCP option creation tasks
+    ansible.builtin.assert:
+      that:
+        - cm_add_dhcp_option is changed
+        - cm_add_dhcp_option.previous == []
+        - cm_add_dhcp_option.current == []
+        - nm_add_dhcp_option is changed
+        - nm_add_dhcp_option.current.0.dhcpOption.attributes.name == "ansible_dhcp_option_1"
+        - nm_add_dhcp_option.current.0.dhcpOption.attributes.id == "1"
+        - nm_add_dhcp_option.current.0.dhcpOption.attributes.data == "82"
+        - nm_add_dhcp_option_idempotency is not changed
+        - nm_add_dhcp_option_2 is changed
+        - nm_add_dhcp_option_2.previous == []
+        - nm_add_dhcp_option_2.current.0.dhcpOption.attributes.name == "ansible_dhcp_option_2"
+        - nm_add_dhcp_option_2.current.0.dhcpOption.attributes.id == "2"
+        - nm_add_dhcp_option_2.current.0.dhcpOption.attributes.data == "252"
+
+  # QUERY DHCP OPTION
+  - name: Query all DHCP options
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_info
+      state: query
+    register: query_all_dhcp_option
+
+  - name: Query ansible_dhcp_option_1
+    cisco.aci.aci_dhcp_option:
+      <<: *aci_dhcp_option_present
+      state: query
+    register: query_ansible_dhcp_option_1
+
+  - name: Asserts query tasks
+    ansible.builtin.assert:
+      that:
+        - query_all_dhcp_option is not changed
+        - query_all_dhcp_option.current|length >= 2
+        - query_ansible_dhcp_option_1 is not changed
+        - query_ansible_dhcp_option_1.current.0.dhcpOption.attributes.name == "ansible_dhcp_option_1"
+        - query_ansible_dhcp_option_1.current.0.dhcpOption.attributes.id == "1"
+        - query_ansible_dhcp_option_1.current.0.dhcpOption.attributes.data == "82"
+
+  # DELETE DHCP OPTION
+  - name: Remove DHCP option (check_mode)
+    cisco.aci.aci_dhcp_option: &dhcp_option_absent
+      <<: *aci_dhcp_option_present
+      state: absent
+    check_mode: true
+    register: cm_remove_dhcp_option
+
+  - name: Remove DHCP option (normal_mode)
+    cisco.aci.aci_dhcp_option:
+      <<: *dhcp_option_absent
+    register: nm_remove_dhcp_option
+
+  - name: Remove DHCP option - testing idempotency
+    cisco.aci.aci_dhcp_option:
+      <<: *dhcp_option_absent
+    register: nm_remove_dhcp_option_idempotency
+
+  - name: Asserts deletion tasks
+    ansible.builtin.assert:
+      that:
+        - cm_remove_dhcp_option is changed
+        - cm_remove_dhcp_option.proposed == {}
+        - nm_remove_dhcp_option is changed
+        - nm_remove_dhcp_option.previous != []
+        - nm_remove_dhcp_option.method == "DELETE"
+        - nm_remove_dhcp_option_idempotency is not changed
+        - nm_remove_dhcp_option_idempotency.previous == []
+
+  # CLEAN ENVIRONMENT BEFORE ENDING TESTS
+  - name: Remove the ansible_tenant - cleanup before ending tests
+    cisco.aci.aci_tenant:
+      <<: *aci_tenant_present
+      state: absent

--- a/tests/integration/targets/aci_dhcp_option_policy/aliases
+++ b/tests/integration/targets/aci_dhcp_option_policy/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_dhcp_option_policy/tasks/main.yml
+++ b/tests/integration/targets/aci_dhcp_option_policy/tasks/main.yml
@@ -1,0 +1,139 @@
+# Test code for the ACI modules
+# Copyright: (c) 2023, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: debug
+
+# CLEAN ENVIRONMENT BEFORE TESTS
+- name: Remove the ansible_tenant
+  cisco.aci.aci_tenant: &aci_tenant_absent
+    <<: *aci_info 
+    tenant: ansible_tenant
+    state: absent
+
+- name: Verify Cloud and Non-Cloud Sites in use.
+  ansible.builtin.include_tasks: ../../../../../../integration/targets/aci_cloud_provider/tasks/main.yml
+
+- name: Execute tasks only for non-cloud sites
+  when: query_cloud.current == []  # This condition will execute only non-cloud sites
+  block:  # block specifies execution of tasks within, based on conditions
+  - name: Add a new tenant
+    cisco.aci.aci_tenant: &aci_tenant_present
+      <<: *aci_info
+      tenant: ansible_tenant
+      description: Ansible tenant
+      state: present
+
+  # CREATE DHCP OPTION POLICY
+  - name: Add a DHCP option policy (check_mode)
+    cisco.aci.aci_dhcp_option_policy: &aci_dhcp_option_policy_present
+      <<: *aci_info
+      tenant: ansible_tenant
+      dhcp_option_policy: ansible_dhcp_option_policy_1
+      description: DHCP option policy 1 for ansible_tenant tenant
+      state: present
+    check_mode: true
+    register: cm_add_dhcp_option_policy
+
+  - name: Add a DHCP option policy (normal_mode)
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_dhcp_option_policy_present
+    register: nm_add_dhcp_option_policy
+
+  - name: Add the first DHCP option policy again - testing idempotency
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_dhcp_option_policy_present
+    register: nm_add_dhcp_option_policy_idempotency
+
+  - name: Add a second DHCP option policy (normal_mode)
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_info
+      tenant: ansible_tenant
+      dhcp_option_policy: ansible_dhcp_option_policy_2
+      description: DHCP option policy 2 for ansible_tenant tenant
+      state: present
+    register: nm_add_dhcp_option_policy_2
+
+  - name: Asserts for DHCP option policy creation tasks
+    ansible.builtin.assert:
+      that:
+        - cm_add_dhcp_option_policy is changed
+        - cm_add_dhcp_option_policy.previous == []
+        - cm_add_dhcp_option_policy.current == []
+        - nm_add_dhcp_option_policy is changed
+        - nm_add_dhcp_option_policy.current.0.dhcpOptionPol.attributes.name == "ansible_dhcp_option_policy_1"
+        - nm_add_dhcp_option_policy_idempotency is not changed
+        - nm_add_dhcp_option_policy_2 is changed
+        - nm_add_dhcp_option_policy_2.previous == []
+        - nm_add_dhcp_option_policy_2.current.0.dhcpOptionPol.attributes.name == "ansible_dhcp_option_policy_2"
+
+  # QUERY DHCP OPTION POLICY
+  - name: Query all DHCP option policies
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_info
+      state: query
+    register: query_all_dhcp_option_policy
+
+  - name: Query ansible_dhcp_option_policy_1
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_dhcp_option_policy_present
+      state: query
+    register: query_ansible_dhcp_option_policy_1
+
+  - name: Asserts query tasks
+    ansible.builtin.assert:
+      that:
+        - query_all_dhcp_option_policy is not changed
+        - query_all_dhcp_option_policy.current|length >= 2
+        - query_ansible_dhcp_option_policy_1 is not changed
+        - query_ansible_dhcp_option_policy_1.current.0.dhcpOptionPol.attributes.name == "ansible_dhcp_option_policy_1"
+
+  # DELETE DHCP OPTION POLICY
+  - name: Remove DHCP option policy (check_mode)
+    cisco.aci.aci_dhcp_option_policy: &dhcp_option_policy_absent
+      <<: *aci_dhcp_option_policy_present
+      state: absent
+    check_mode: true
+    register: cm_remove_dhcp_option_policy
+
+  - name: Remove DHCP option policy (normal_mode)
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *dhcp_option_policy_absent
+    register: nm_remove_dhcp_option_policy
+
+  - name: Remove DHCP option policy - testing idempotency
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *dhcp_option_policy_absent
+    register: nm_remove_dhcp_option_policy_idempotency
+
+  - name: Asserts deletion tasks
+    ansible.builtin.assert:
+      that:
+        - cm_remove_dhcp_option_policy is changed
+        - cm_remove_dhcp_option_policy.proposed == {}
+        - nm_remove_dhcp_option_policy is changed
+        - nm_remove_dhcp_option_policy.previous != []
+        - nm_remove_dhcp_option_policy.method == "DELETE"
+        - nm_remove_dhcp_option_policy_idempotency is not changed
+        - nm_remove_dhcp_option_policy_idempotency.previous == []
+
+  # CLEAN ENVIRONMENT BEFORE ENDING TESTS
+  - name: Remove the ansible_tenant - cleanup before ending tests
+    cisco.aci.aci_tenant:
+      <<: *aci_tenant_present
+      state: absent

--- a/tests/integration/targets/aci_l3out_dhcp_relay_label/aliases
+++ b/tests/integration/targets/aci_l3out_dhcp_relay_label/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_l3out_dhcp_relay_label/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_dhcp_relay_label/tasks/main.yml
@@ -130,7 +130,7 @@
       state: present
     register: nm_add_l3out_dhcp_relay_label_2
 
-  - name: Asserts for eigrp interface policies creation tasks
+  - name: Asserts for DHCP relay labels creation tasks
     ansible.builtin.assert:
       that:
         - cm_add_l3out_dhcp_relay_label is changed
@@ -168,9 +168,44 @@
         - query_ansible_l3out_dhcp_relay_label_1.current.0.dhcpLbl.attributes.owner == "tenant"
         - query_ansible_l3out_dhcp_relay_label_1.current.0.dhcpLbl.children.0.dhcpRsDhcpOptionPol.attributes.tnDhcpOptionPolName == "ansible_dhcp_option_policy"
 
+  - name: Update first L3out DHCP relay label by deleting current DHCP options (check_mode)
+    cisco.aci.aci_l3out_dhcp_relay_label: &aci_l3out_dhcp_relay_label_update
+      <<: *aci_l3out_dhcp_relay_label_present
+      dhcp_option_policy: ""
+    check_mode: true
+    register: cm_update_l3out_dhcp_relay_label
+
+  - name: Update first L3out DHCP relay label by deleting current DHCP options (normal_mode)
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_dhcp_relay_label_update
+    register: nm_update_l3out_dhcp_relay_label
+  
+  - name: Update first L3out DHCP relay label by deleting current DHCP options again - testing idempotency
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_dhcp_relay_label_update
+    register: nm_update_l3out_dhcp_relay_label_idempotency
+
+  - name: Query updated first L3Out DHCP relay label
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_dhcp_relay_label_update
+      state: query
+    register: query_ansible_l3out_dhcp_relay_label_1_updated
+
+  - name: Asserts for DHCP relay labels update tasks
+    ansible.builtin.assert:
+      that:
+        - cm_update_l3out_dhcp_relay_label is changed
+        - cm_update_l3out_dhcp_relay_label.previous == cm_update_l3out_dhcp_relay_label.current
+        - nm_update_l3out_dhcp_relay_label is changed
+        - nm_update_l3out_dhcp_relay_label.current.0.dhcpLbl.children.0.dhcpRsDhcpOptionPol.attributes.tnDhcpOptionPolName == ""
+        - nm_update_l3out_dhcp_relay_label_idempotency is not changed
+        - query_ansible_l3out_dhcp_relay_label_1_updated is not changed
+        - query_ansible_l3out_dhcp_relay_label_1_updated.current.0.dhcpLbl.children.0.dhcpRsDhcpOptionPol.attributes.tDn == "uni/tn-common/dhcpoptpol-default"
+        - query_ansible_l3out_dhcp_relay_label_1_updated.current.0.dhcpLbl.children.0.dhcpRsDhcpOptionPol.attributes.tnDhcpOptionPolName == ""
+
   - name: Remove L3Out DHCP relay label from interface profile (check_mode)
     cisco.aci.aci_l3out_dhcp_relay_label: &l3out_dhcp_relay_label_absent
-      <<: *aci_l3out_dhcp_relay_label_present
+      <<: *aci_l3out_dhcp_relay_label_update
       state: absent
     check_mode: true
     register: cm_remove_l3out_dhcp_relay_label

--- a/tests/integration/targets/aci_l3out_dhcp_relay_label/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_dhcp_relay_label/tasks/main.yml
@@ -1,0 +1,207 @@
+# Test code for the ACI modules
+# Copyright: (c) 2023, Gaspard Micol (@gmicol) <gmicol@cisco.com>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: debug
+
+# CLEAN ENVIRONMENT
+- name: Remove the ansible_tenant
+  cisco.aci.aci_tenant: &aci_tenant_absent
+    <<: *aci_info 
+    tenant: ansible_tenant
+    state: absent
+
+- name: Verify Cloud and Non-Cloud Sites in use.
+  ansible.builtin.include_tasks: ../../../../../../integration/targets/aci_cloud_provider/tasks/main.yml
+
+- name: Execute tasks only for non-cloud sites
+  when: query_cloud.current == []  # This condition will execute only non-cloud sites
+  block:  # block specifies execution of tasks within, based on conditions
+  - name: Add a new tenant
+    cisco.aci.aci_tenant: &aci_tenant_present
+      <<: *aci_info
+      tenant: ansible_tenant
+      description: Ansible tenant
+      state: present
+    
+  - name: Add new Domain
+    cisco.aci.aci_domain: &aci_domain_present
+      <<: *aci_info
+      domain: ansible_dom
+      domain_type: l3dom
+      state: present
+
+  - name: Addd a new VRF
+    cisco.aci.aci_vrf: &aci_vrf_present
+      <<: *aci_tenant_present
+      vrf: ansible_vrf
+      description: Ansible VRF
+
+  - name: Add a new L3Out
+    cisco.aci.aci_l3out: &aci_l3out_present
+      <<: *aci_vrf_present
+      l3out: ansible_l3out
+      domain: ansible_dom
+      route_control: export
+      l3protocol: eigrp
+      asn: 1
+      description: Ansible L3Out
+
+  - name: Add a new L3Out logical node profile
+    cisco.aci.aci_l3out_logical_node_profile: &aci_l3out_node_profile_present
+      <<: *aci_tenant_present
+      l3out: ansible_l3out
+      node_profile: ansible_l3out_node_profile
+      description: Ansible L3Out Logical Node Profile
+
+  - name: Add a new L3Out logical interface profile
+    cisco.aci.aci_l3out_logical_interface_profile: &aci_l3out_interface_profile_present
+      <<: *aci_l3out_node_profile_present
+      interface_profile: ansible_l3out_interface_profile
+      description: First Ansible L3Out Logical Interface Profile
+
+  - name: Add a new DHCP relay policy in infra
+    cisco.aci.aci_dhcp_relay:
+      <<: *aci_info
+      relay_policy: ansible_dhcp_relay_policy_infra
+      description: Ansible DHCP Relay Policy in infra
+      state: present
+
+  - name: Add a new DHCP relay policy in ansible tenant
+    cisco.aci.aci_dhcp_relay:
+      <<: *aci_tenant_present
+      relay_policy: ansible_dhcp_relay_policy_tenant
+      description: Ansible DHCP Relay Policy in tenant
+      state: present
+
+  - name: Add a new DHCP option policy
+    cisco.aci.aci_dhcp_option_policy:
+      <<: *aci_tenant_present
+      dhcp_option_policy: ansible_dhcp_option_policy
+      description: Ansible DHCP Option Policy
+      state: present
+  
+  - name: Add L3Out DHCP Relay Label to first interface profile (check mode)
+    cisco.aci.aci_l3out_dhcp_relay_label: &aci_l3out_dhcp_relay_label_present
+      <<: *aci_l3out_interface_profile_present
+      dhcp_relay_label: ansible_dhcp_relay_policy_tenant
+      scope: tenant
+      dhcp_option_policy: ansible_dhcp_option_policy
+      description: First Ansible DHCP Relay Label
+    check_mode: true
+    register: cm_add_l3out_dhcp_relay_label
+
+  - name: Add L3Out DHCP Relay Label to first interface profile (normal mode)
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_dhcp_relay_label_present
+    register: nm_add_l3out_dhcp_relay_label
+
+  - name: Add L3Out DHCP relay label to first interface profile again - testing idempotency
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_dhcp_relay_label_present
+    register: nm_add_l3out_dhcp_relay_label_idempotency
+
+  - name: Create a second L3Out logical interface profile
+    cisco.aci.aci_l3out_logical_interface_profile: &aci_l3out_interface_profile_present_2
+      <<: *aci_l3out_node_profile_present
+      interface_profile: ansible_l3out_interface_profile_2
+      description: Second Ansible L3Out Logical Interface Profile
+
+  - name: Add L3Out DHCP Relay Label to second interface profile (normal_mode)
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_interface_profile_present_2
+      dhcp_relay_label: ansible_dhcp_relay_policy_infra
+      description: Second Ansible DHCP Relay Label
+      state: present
+    register: nm_add_l3out_dhcp_relay_label_2
+
+  - name: Asserts for eigrp interface policies creation tasks
+    ansible.builtin.assert:
+      that:
+        - cm_add_l3out_dhcp_relay_label is changed
+        - cm_add_l3out_dhcp_relay_label.previous == []
+        - cm_add_l3out_dhcp_relay_label.current == []
+        - nm_add_l3out_dhcp_relay_label is changed
+        - nm_add_l3out_dhcp_relay_label.current.0.dhcpLbl.attributes.name == "ansible_dhcp_relay_policy_tenant"
+        - nm_add_l3out_dhcp_relay_label.current.0.dhcpLbl.attributes.owner == "tenant"
+        - nm_add_l3out_dhcp_relay_label.current.0.dhcpLbl.children.0.dhcpRsDhcpOptionPol.attributes.tnDhcpOptionPolName == "ansible_dhcp_option_policy"
+        - nm_add_l3out_dhcp_relay_label_idempotency is not changed
+        - nm_add_l3out_dhcp_relay_label_2 is changed
+        - nm_add_l3out_dhcp_relay_label_2.previous == []
+        - nm_add_l3out_dhcp_relay_label_2.current.0.dhcpLbl.attributes.name == "ansible_dhcp_relay_policy_infra"
+        - nm_add_l3out_dhcp_relay_label_2.current.0.dhcpLbl.attributes.owner == "infra"
+
+  - name: Query all l3Out DHCP relay labels
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_info
+      state: query
+    register: query_all_l3out_dhcp_relay_label
+
+  - name: Query first L3Out DHCP relay label
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *aci_l3out_dhcp_relay_label_present
+      state: query
+    register: query_ansible_l3out_dhcp_relay_label_1
+
+  - name: Asserts query tasks
+    ansible.builtin.assert:
+      that:
+        - query_all_l3out_dhcp_relay_label is not changed
+        - query_all_l3out_dhcp_relay_label.current|length >= 2
+        - query_ansible_l3out_dhcp_relay_label_1 is not changed
+        - query_ansible_l3out_dhcp_relay_label_1.current.0.dhcpLbl.attributes.name == "ansible_dhcp_relay_policy_tenant"
+        - query_ansible_l3out_dhcp_relay_label_1.current.0.dhcpLbl.attributes.owner == "tenant"
+        - query_ansible_l3out_dhcp_relay_label_1.current.0.dhcpLbl.children.0.dhcpRsDhcpOptionPol.attributes.tnDhcpOptionPolName == "ansible_dhcp_option_policy"
+
+  - name: Remove L3Out DHCP relay label from interface profile (check_mode)
+    cisco.aci.aci_l3out_dhcp_relay_label: &l3out_dhcp_relay_label_absent
+      <<: *aci_l3out_dhcp_relay_label_present
+      state: absent
+    check_mode: true
+    register: cm_remove_l3out_dhcp_relay_label
+
+  - name: Remove L3Out DHCP relay label from interface profile (normal_mode)
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *l3out_dhcp_relay_label_absent
+    register: nm_remove_l3out_dhcp_relay_label
+
+  - name: Remove L3Out DHCP relay label from interface profile - testing idempotency
+    cisco.aci.aci_l3out_dhcp_relay_label:
+      <<: *l3out_dhcp_relay_label_absent
+    register: nm_remove_l3out_dhcp_relay_label_idempotency
+
+  - name: Asserts deletion tasks
+    ansible.builtin.assert:
+      that:
+        - cm_remove_l3out_dhcp_relay_label is changed
+        - cm_remove_l3out_dhcp_relay_label.proposed == {}
+        - nm_remove_l3out_dhcp_relay_label is changed
+        - nm_remove_l3out_dhcp_relay_label.previous != []
+        - nm_remove_l3out_dhcp_relay_label.method == "DELETE"
+        - nm_remove_l3out_dhcp_relay_label_idempotency is not changed
+        - nm_remove_l3out_dhcp_relay_label_idempotency.previous == []
+
+  - name: Remove the ansible_tenant - cleanup before ending tests
+    cisco.aci.aci_tenant:
+      <<: *aci_tenant_present
+      state: absent
+
+  - name: Remove the ansible_dom - cleanup before ending tests
+    cisco.aci.aci_domain:
+      <<: *aci_domain_present
+      state: absent


### PR DESCRIPTION
New Modules Added:

- [x] aci_l3out_dhcp_relay_label (dhcp:Lbl)
- [x] aci_dhcp_option_policy (dhcp:OptionPol)
- [x] aci_dhcp_option (dhcp:Option)