### PR TITLE
Add auto to link level speed options

### DIFF
--- a/plugins/modules/aci_interface_policy_link_level.py
+++ b/plugins/modules/aci_interface_policy_link_level.py
@@ -35,7 +35,7 @@ options:
     default: true
   speed:
     description:
-    - Determines the interface policy administrative port speed. 
+    - Determines the interface policy administrative port speed.
     - The C(auto) option is only supported in APIC version 5.2 or later.
     - The APIC defaults to C(inherit) when unset during creation.
     type: str

--- a/plugins/modules/aci_interface_policy_link_level.py
+++ b/plugins/modules/aci_interface_policy_link_level.py
@@ -35,7 +35,8 @@ options:
     default: true
   speed:
     description:
-    - Determines the interface policy administrative port speed. (note: "auto" is only supported from APIC versions >= 5.2)
+    - Determines the interface policy administrative port speed. 
+    - The C(auto) option is only supported in APIC version 5.2 or later.
     - The APIC defaults to C(inherit) when unset during creation.
     type: str
     choices: [ 100M, 1G, 10G, 25G, 40G, 50G, 100G, 200G, 400G, auto, inherit ]

--- a/plugins/modules/aci_interface_policy_link_level.py
+++ b/plugins/modules/aci_interface_policy_link_level.py
@@ -38,7 +38,7 @@ options:
     - Determines the interface policy administrative port speed.
     - The APIC defaults to C(inherit) when unset during creation.
     type: str
-    choices: [ 100M, 1G, 10G, 25G, 40G, 50G, 100G, 200G, 400G, inherit ]
+    choices: [ 100M, 1G, 10G, 25G, 40G, 50G, 100G, 200G, 400G, auto, inherit ]
     default: inherit
   link_debounce_interval:
     description:

--- a/plugins/modules/aci_interface_policy_link_level.py
+++ b/plugins/modules/aci_interface_policy_link_level.py
@@ -231,7 +231,7 @@ def main():
         link_level_policy=dict(type="str", aliases=["name"]),
         description=dict(type="str", aliases=["descr"]),
         auto_negotiation=dict(type="bool", default="true"),
-        speed=dict(type="str", default="inherit", choices=["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "inherit"]),
+        speed=dict(type="str", default="inherit", choices=["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]),
         link_debounce_interval=dict(type="int", default="100"),
         forwarding_error_correction=dict(
             type="str", default="inherit", choices=["inherit", "kp-fec", "cl91-rs-fec", "cl74-fc-fec", "disable-fec", "ieee-rs-fec", "cons16-rs-fec"]

--- a/plugins/modules/aci_interface_policy_link_level.py
+++ b/plugins/modules/aci_interface_policy_link_level.py
@@ -35,7 +35,7 @@ options:
     default: true
   speed:
     description:
-    - Determines the interface policy administrative port speed.
+    - Determines the interface policy administrative port speed. (note: "auto" is only supported from APIC versions >= 5.2)
     - The APIC defaults to C(inherit) when unset during creation.
     type: str
     choices: [ 100M, 1G, 10G, 25G, 40G, 50G, 100G, 200G, 400G, auto, inherit ]

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -15,6 +15,19 @@
 - name: Execute tasks only for non-cloud sites
   when: query_cloud.current == []  # This condition will execute only non-cloud sites
   block:  # block specifies execution of tasks within, based on conditions
+  # SET ACI_INFO VARS FOR SYSTEM LOGIN WITHIN TASKS
+  - name: Set vars for system login 
+    ansible.builtin.set_fact:
+     aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      port: "{{ aci_port | default(omit) }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: '{{ aci_output_level | default("info") }}'
+
   # CLEAN ENVIRONMENT
   - name: Remove Link Level Policy
     cisco.aci.aci_interface_policy_link_level: &interface_policy_link_level_absent
@@ -142,15 +155,9 @@
   # CHANGE SPEED ON LINK LEVEL POLICY
   - name: Test each speed setting for Link Level Policy
     block:
-      - name: Query system information
+      - name: Query system information to fetch version
         cisco.aci.aci_system:
-          host: '{{ aci_hostname }}'
-          username: '{{ aci_username }}'
-          password: '{{ aci_password }}'
-          validate_certs: '{{ aci_validate_certs | default(false) }}'
-          use_ssl: '{{ aci_use_ssl | default(true) }}'
-          use_proxy: '{{ aci_use_proxy | default(true) }}'
-          output_level: '{{ aci_output_level | default("info") }}'
+          <<: *aci_info
           id: 1
           state: query
         register: version

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -149,19 +149,26 @@
         check_mode: true
         loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
         register: cm_add_policy_speed
+        loop_control:
+          label: "speed-{{ item }}"
 
-  - name: Add Link Level Policy with various speeds (normal mode)
-    cisco.aci.aci_interface_policy_link_level:
-      <<: *interface_policy_link_level_present
-      speed: "{{ item }}"
-    loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
-    register: nm_add_policy_speed
-
-  - name: Verify each speed setting
-    ansible.builtin.assert:
-      that:
-        - "item.1.current.0.fabricHIfPol.attributes.speed == item.0"
-    loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(nm_add_policy_speed.results) }}"
+      - name: Add Link Level Policy with various speeds (normal mode)
+        cisco.aci.aci_interface_policy_link_level:
+          <<: *interface_policy_link_level_present
+          speed: "{{ item }}"
+        loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
+        register: nm_add_policy_speed
+        loop_control:
+          label: "speed-{{ item }}"
+    
+      - name: Verify each speed setting
+        ansible.builtin.assert:
+          that:
+            - "item.1.current.0.fabricHIfPol.attributes.speed == item.0"
+          quiet: true
+        loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(nm_add_policy_speed.results) }}"
+        loop_control:
+          label: "speed-{{ item }}"
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -168,7 +168,7 @@
           quiet: true
         loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(nm_add_policy_speed.results) }}"
         loop_control:
-          label: "speed-{{ item }}"
+          label: "speed-{{ item.0 }}"
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -213,7 +213,6 @@
         loop: "{{ supported_speed | zip(cm_add_policy_speed.results) }}"
         loop_control:
           label: "speed-{{ item.0 }}"
-    ignore_errors: true
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -138,6 +138,30 @@
       - cm_add_policy_again_no_descr.proposed.fabricHIfPol.attributes.name == nm_add_policy_again_no_descr.proposed.fabricHIfPol.attributes.name == 'ansible_test'
       - cm_add_policy_again_no_descr.sent == nm_add_policy_again_no_descr.sent == {}
       - cm_add_policy_again_no_descr.previous.0.fabricHIfPol.attributes.dn== nm_add_policy_again_no_descr.previous.0.fabricHIfPol.attributes.dn == cm_add_policy_again_no_descr.current.0.fabricHIfPol.attributes.dn == nm_add_policy_again_no_descr.current.0.fabricHIfPol.attributes.dn == 'uni/infra/hintfpol-ansible_test'
+  
+  # CHANGE SPEED ON LINK LEVEL POLICY
+  - name: Test each speed setting for Link Level Policy
+    block:
+      - name: Add Link Level Policy with various speeds (check mode)
+        cisco.aci.aci_interface_policy_link_level:
+          <<: *interface_policy_link_level_present
+          speed: "{{ item }}"
+        check_mode: true
+        loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
+        register: cm_add_policy_speed
+
+  - name: Add Link Level Policy with various speeds (normal mode)
+    cisco.aci.aci_interface_policy_link_level:
+      <<: *interface_policy_link_level_present
+      speed: "{{ item }}"
+    loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
+    register: nm_add_policy_speed
+
+  - name: Verify each speed setting
+    ansible.builtin.assert:
+      that:
+        - "item.1.current.0.fabricHIfPol.attributes.speed == item.0"
+    loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(nm_add_policy_speed.results) }}"
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -173,10 +173,11 @@
       - name: Verify each speed setting (check mode)
         ansible.builtin.assert:
           that:
-            - item is changed
-        loop: "{{ cm_add_policy_speed.results }}"
+            - "item.1.current.0.fabricHIfPol.attributes.speed == 'inherit'"
+            - "item.1.proposed.fabricHIfPol.attributes.speed == item.0"
+        loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(cm_add_policy_speed.results) }}"
         loop_control:
-          label: "speed-{{ item }}"
+          label: "speed-{{ item.0 }}"
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -142,12 +142,35 @@
   # CHANGE SPEED ON LINK LEVEL POLICY
   - name: Test each speed setting for Link Level Policy
     block:
+      - name: Query system information
+        cisco.aci.aci_system:
+          host: '{{ aci_hostname }}'
+          username: '{{ aci_username }}'
+          password: '{{ aci_password }}'
+          validate_certs: '{{ aci_validate_certs | default(false) }}'
+          use_ssl: '{{ aci_use_ssl | default(true) }}'
+          use_proxy: '{{ aci_use_proxy | default(true) }}'
+          output_level: '{{ aci_output_level | default("info") }}'
+          id: 1
+          state: query
+        register: version
+
+      - name: Define speed settings in version < 5.2
+        set_fact:
+          supported_speed: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "inherit"]
+        when: version.current.0.topSystem.attributes.version is version('5.2', '<')
+
+      - name: Define speed settings in version >= 5.2
+        set_fact:
+          supported_speed: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
+        when: version.current.0.topSystem.attributes.version is version('5.2', '>=')
+
       - name: Add Link Level Policy with various speeds (check mode)
         cisco.aci.aci_interface_policy_link_level:
           <<: *interface_policy_link_level_present
           speed: "{{ item }}"
         check_mode: true
-        loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto"]
+        loop: "{{ supported_speed }}"
         register: cm_add_policy_speed
         loop_control:
           label: "speed-{{ item }}"
@@ -156,7 +179,7 @@
         cisco.aci.aci_interface_policy_link_level:
           <<: *interface_policy_link_level_present
           speed: "{{ item }}"
-        loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
+        loop: "{{ supported_speed }}"
         register: nm_add_policy_speed
         loop_control:
           label: "speed-{{ item }}"
@@ -164,20 +187,26 @@
       - name: Verify each speed setting (normal mode)
         ansible.builtin.assert:
           that:
+            - "item.1.current.0.fabricHIfPol.attributes.name == 'ansible_test'"
+            - "item.1.current.0.fabricHIfPol.attributes.dn ==  'uni/infra/hintfpol-ansible_test'"
             - "item.1.current.0.fabricHIfPol.attributes.speed == item.0"
           quiet: true
-        loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(nm_add_policy_speed.results) }}"
+        loop: "{{ supported_speed | zip(nm_add_policy_speed.results) }}"
         loop_control:
           label: "speed-{{ item.0 }}"
 
       - name: Verify each speed setting (check mode)
         ansible.builtin.assert:
           that:
+            - "item.1.current.0.fabricHIfPol.attributes.name == 'ansible_test'"
+            - "item.1.current.0.fabricHIfPol.attributes.dn ==  'uni/infra/hintfpol-ansible_test'"
             - "item.1.current.0.fabricHIfPol.attributes.speed == 'inherit'"
             - "item.1.proposed.fabricHIfPol.attributes.speed == item.0"
-        loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(cm_add_policy_speed.results) }}"
+          quiet: true
+        loop: "{{ supported_speed | zip(cm_add_policy_speed.results) }}"
         loop_control:
           label: "speed-{{ item.0 }}"
+    ignore_errors: true
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)

--- a/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
+++ b/tests/integration/targets/aci_interface_policy_link_level/tasks/main.yml
@@ -147,7 +147,7 @@
           <<: *interface_policy_link_level_present
           speed: "{{ item }}"
         check_mode: true
-        loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto", "inherit"]
+        loop: ["100M", "1G", "10G", "25G", "40G", "50G", "100G", "200G", "400G", "auto"]
         register: cm_add_policy_speed
         loop_control:
           label: "speed-{{ item }}"
@@ -161,7 +161,7 @@
         loop_control:
           label: "speed-{{ item }}"
     
-      - name: Verify each speed setting
+      - name: Verify each speed setting (normal mode)
         ansible.builtin.assert:
           that:
             - "item.1.current.0.fabricHIfPol.attributes.speed == item.0"
@@ -169,6 +169,14 @@
         loop: "{{ ['100M', '1G', '10G', '25G', '40G', '50G', '100G', '200G', '400G', 'auto', 'inherit'] | zip(nm_add_policy_speed.results) }}"
         loop_control:
           label: "speed-{{ item.0 }}"
+
+      - name: Verify each speed setting (check mode)
+        ansible.builtin.assert:
+          that:
+            - item is changed
+        loop: "{{ cm_add_policy_speed.results }}"
+        loop_control:
+          label: "speed-{{ item }}"
 
   # QUERY ALL LINK LEVEL POLICIES
   - name: Query all Link Level Policies (check mode)


### PR DESCRIPTION
"auto" for the link level policy is missing from the choices in the ansible module. This adds the "auto" option to allow an auto negotiating interface speed to be configured on the APIC controller