### PR TITLE
[ignore] Pinned CI galaxy-importer version to 4.20

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -77,8 +77,8 @@ jobs:
     - name: Install the collection tarball
       run: ansible-galaxy collection install .cache/collection-tarballs/*.tar.gz
 
-    - name: Install galaxy-importer
-      run: pip install galaxy-importer
+    - name: Install galaxy-importer (v0.4.20)
+      run: pip install galaxy-importer==0.4.20
 
     - name: Create galaxy-importer directory
       run: sudo mkdir -p /etc/galaxy-importer


### PR DESCRIPTION
I had to pin to this version because the latest versions (0.4.21) released last week prints out quite a few unrelated warnings and fails the CI.

This is a temporary fix. The full fix should be completed as part of #639