### PR TITLE
[bug_fix]: Add subclass to `aci_domain_to_vlan_pool` to fix deletion of binding (DCNE-207)

### DIFF
--- a/plugins/modules/aci_domain_to_vlan_pool.py
+++ b/plugins/modules/aci_domain_to_vlan_pool.py
@@ -334,7 +334,7 @@ def main():
             aci_class="infraRsVlanNs",
             aci_rn="rsvlanNs",
             target_filter={"dn": "{0}/rsvlanNs".format(domain_mo)},
-        )
+        ),
     )
 
     aci.get_existing()

--- a/plugins/modules/aci_domain_to_vlan_pool.py
+++ b/plugins/modules/aci_domain_to_vlan_pool.py
@@ -333,8 +333,8 @@ def main():
         subclass_1=dict(
             aci_class="infraRsVlanNs",
             aci_rn="rsvlanNs",
-            module_object="rsvlanNs",
-            target_filter={"name": domain},
+            module_object=aci_mo if pool_name else None,
+            target_filter={"tDn": aci_mo} if pool_name else {},
         ),
     )
 

--- a/plugins/modules/aci_domain_to_vlan_pool.py
+++ b/plugins/modules/aci_domain_to_vlan_pool.py
@@ -330,21 +330,22 @@ def main():
             module_object=domain_mo,
             target_filter={"name": domain},
         ),
-        child_classes=["infraRsVlanNs"],
+        subclass_1=dict(
+            aci_class="infraRsVlanNs",
+            aci_rn="rsvlanNs",
+            target_filter={"dn": "{0}/rsvlanNs".format(domain_mo)},
+        )
     )
 
     aci.get_existing()
 
     if state == "present":
         aci.payload(
-            aci_class=domain_class,
-            class_config=dict(name=domain),
-            child_configs=[
-                {"infraRsVlanNs": {"attributes": {"tDn": aci_mo}}},
-            ],
+            aci_class="infraRsVlanNs",
+            class_config=dict(tDn=aci_mo),
         )
 
-        aci.get_diff(aci_class=domain_class)
+        aci.get_diff(aci_class="infraRsVlanNs")
 
         aci.post_config()
 

--- a/plugins/modules/aci_domain_to_vlan_pool.py
+++ b/plugins/modules/aci_domain_to_vlan_pool.py
@@ -334,7 +334,7 @@ def main():
             aci_class="infraRsVlanNs",
             aci_rn="rsvlanNs",
             module_object="rsvlanNs",
-            target_filter={"tDn": aci_mo},
+            target_filter={"name": domain},
         ),
     )
 

--- a/plugins/modules/aci_domain_to_vlan_pool.py
+++ b/plugins/modules/aci_domain_to_vlan_pool.py
@@ -333,7 +333,8 @@ def main():
         subclass_1=dict(
             aci_class="infraRsVlanNs",
             aci_rn="rsvlanNs",
-            target_filter={"dn": "{0}/rsvlanNs".format(domain_mo)},
+            module_object="rsvlanNs",
+            target_filter={"tDn": aci_mo},
         ),
     )
 

--- a/tests/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
+++ b/tests/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
@@ -85,15 +85,11 @@
       that:
       - cm_add_binding is changed
       - nm_add_binding is changed
-      - cm_add_binding.sent.physDomP.attributes.name == nm_add_binding.sent.physDomP.attributes.name == 'phys_dom'
-      - cm_add_binding.sent.physDomP.children.0.infraRsVlanNs.attributes.tDn == nm_add_binding.sent.physDomP.children.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
-      - cm_add_binding.proposed.physDomP.attributes.name == nm_add_binding.proposed.physDomP.attributes.name == 'phys_dom'
-      - cm_add_binding.proposed.physDomP.children.0.infraRsVlanNs.attributes.tDn == nm_add_binding.proposed.physDomP.children.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
+      - cm_add_binding.proposed.infraRsVlanNs.attributes.tDn == nm_add_binding.proposed.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
       - cm_add_binding.current == cm_add_binding.previous == nm_add_binding.previous == []
-      - nm_add_binding.current.0.physDomP.attributes.annotation == 'orchestrator:ansible'
-      - nm_add_binding.current.0.physDomP.attributes.name == 'phys_dom'
-      - nm_add_binding.current.0.physDomP.attributes.dn == 'uni/phys-phys_dom'
-      - nm_add_binding.current.0.physDomP.children.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
+      - nm_add_binding.current.0.infraRsVlanNs.attributes.annotation == 'orchestrator:ansible'
+      - nm_add_binding.current.0.infraRsVlanNs.attributes.dn == 'uni/phys-phys_dom/rsvlanNs'
+      - nm_add_binding.current.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
 
   - name: Add domain to VLAN pool binding again (check_mode)
     cisco.aci.aci_domain_to_vlan_pool: *binding_present
@@ -155,17 +151,17 @@
       - err_not_vmm_with_vm_provider is not changed
       - err_not_vmm_with_vm_provider.msg == "Domain type 'phys' cannot have a 'vm_provider'"
       - nm_fc_type is changed
-      - nm_fc_type.current.0.fcDomP.attributes.dn == "uni/fc-fc_dom"
-      - nm_fc_type.current.0.fcDomP.children.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-static"
+      - nm_fc_type.current.0.infraRsVlanNs.attributes.dn == "uni/fc-fc_dom/rsvlanNs"
+      - nm_fc_type.current.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-static"
       - nm_l2dom_type is changed
-      - nm_l2dom_type.current.0.l2extDomP.attributes.dn == "uni/l2dom-l2dom_dom"
-      - nm_l2dom_type.current.0.l2extDomP.children.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-dynamic"
+      - nm_l2dom_type.current.0.infraRsVlanNs.attributes.dn == "uni/l2dom-l2dom_dom/rsvlanNs"
+      - nm_l2dom_type.current.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-dynamic"
       - nm_l3dom_type is changed
-      - nm_l3dom_type.current.0.l3extDomP.attributes.dn == "uni/l3dom-l3dom_dom"
-      - nm_l3dom_type.current.0.l3extDomP.children.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-dynamic"
+      - nm_l3dom_type.current.0.infraRsVlanNs.attributes.dn == "uni/l3dom-l3dom_dom/rsvlanNs"
+      - nm_l3dom_type.current.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-dynamic"
       - nm_vmm_type is changed
-      - nm_vmm_type.current.0.vmmDomP.attributes.dn == "uni/vmmp-VMware/dom-anstest"
-      - nm_vmm_type.current.0.vmmDomP.children.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-dynamic"
+      - nm_vmm_type.current.0.infraRsVlanNs.attributes.dn == "uni/vmmp-VMware/dom-anstest/rsvlanNs"
+      - nm_vmm_type.current.0.infraRsVlanNs.attributes.tDn == "uni/infra/vlanns-[test_pool]-dynamic"
 
   # QUERY ALL BINDINGS
   - name: Query all domain to VLAN pool bindings (check_mode)
@@ -214,10 +210,9 @@
       - cm_query_binding is not changed
       - nm_query_binding is not changed
       - cm_query_binding == nm_query_binding
-      - nm_query_binding.current.0.physDomP.attributes.dn == 'uni/phys-phys_dom'
-      - nm_query_binding.current.0.physDomP.attributes.name == 'phys_dom'
-      - nm_query_binding.current.0.physDomP.children.0.infraRsVlanNs.attributes.tCl == 'fvnsVlanInstP'
-      - nm_query_binding.current.0.physDomP.children.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
+      - nm_query_binding.current.0.infraRsVlanNs.attributes.dn == 'uni/phys-phys_dom/rsvlanNs'
+      - nm_query_binding.current.0.infraRsVlanNs.attributes.tCl == 'fvnsVlanInstP'
+      - nm_query_binding.current.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
 
 
   # REMOVE BINDING
@@ -235,9 +230,8 @@
       that:
       - cm_remove_binding is changed
       - nm_remove_binding is changed
-      - cm_remove_binding.current.0.physDomP.attributes.dn == cm_remove_binding.previous.0.physDomP.attributes.dn == nm_remove_binding.previous.0.physDomP.attributes.dn == 'uni/phys-phys_dom'
-      - cm_remove_binding.current.0.physDomP.attributes.name == cm_remove_binding.previous.0.physDomP.attributes.name == nm_remove_binding.previous.0.physDomP.attributes.name == 'phys_dom'
-      - cm_remove_binding.current.0.physDomP.children.0.infraRsVlanNs.attributes.tDn == cm_remove_binding.previous.0.physDomP.children.0.infraRsVlanNs.attributes.tDn == nm_remove_binding.previous.0.physDomP.children.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
+      - cm_remove_binding.current.0.infraRsVlanNs.attributes.dn == cm_remove_binding.previous.0.infraRsVlanNs.attributes.dn == nm_remove_binding.previous.0.infraRsVlanNs.attributes.dn == 'uni/phys-phys_dom/rsvlanNs'
+      - cm_remove_binding.current.0.infraRsVlanNs.attributes.tDn == cm_remove_binding.previous.0.infraRsVlanNs.attributes.tDn == nm_remove_binding.previous.0.infraRsVlanNs.attributes.tDn == 'uni/infra/vlanns-[test_pool]-dynamic'
       - nm_remove_binding.current == []
 
   - name: Remove domain to VLAN pool binding again (check_mode)

--- a/tests/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
+++ b/tests/integration/targets/aci_domain_to_vlan_pool/tasks/main.yml
@@ -63,6 +63,25 @@
       description: Test VLAN pool
       state: present
 
+  - name: Create domains
+    cisco.aci.aci_domain:
+      <<: *aci_info
+      domain: "{{ item.domain }}"
+      domain_type: "{{ item.domain_type }}"
+      state: present
+    loop:
+    - {domain: phys_dom, domain_type: phys}
+    - {domain: fc_dom, domain_type: fc}
+    - {domain: l2dom_dom, domain_type: l2dom}
+    - {domain: l3dom_dom, domain_type: l3dom}
+
+  - name: Add VMM domain
+    cisco.aci.aci_domain:
+      <<: *aci_info
+      domain: anstest
+      domain_type: vmm
+      vm_provider: vmware
+      state: present
 
   # ADD BINDING
   - name: Add domain to VLAN pool binding (check_mode)


### PR DESCRIPTION
When state is absent, only the subclass for the domain should be deleted (infraRsVlanNs) not the whole domain config.