### PR TITLE
Add module for mgmt:OOB to contract binding (mgmtRsOoBProv) (DCNE-212)

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -213,6 +213,7 @@ action_groups:
     - aci_node_mgmt_epg
     - aci_ntp_policy
     - aci_ntp_server
+    - aci_oob_epg_to_contract
     - aci_pim_route_map_entry
     - aci_pim_route_map_policy
     - aci_qos_custom_policy

--- a/plugins/modules/aci_oob_epg_to_contract.py
+++ b/plugins/modules/aci_oob_epg_to_contract.py
@@ -187,8 +187,8 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        epg=dict(type='str', required=True),
-        contract=dict(type='str'),
+        epg=dict(type="str", required=True),
+        contract=dict(type="str"),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
     )
 
@@ -201,9 +201,9 @@ def main():
         ],
     )
 
-    epg = module.params['epg']
-    contract = module.params['contract']
-    state = module.params['state']
+    epg = module.params["epg"]
+    contract = module.params["contract"]
+    state = module.params["state"]
 
     ctProv_mo = "uni/tn-mgmt/oobbrc-{0}".format(contract)
 
@@ -238,10 +238,8 @@ def main():
     aci.get_existing()
 
     if state == "present":
-        aci.payload(
-            aci_class="mgmtRsOoBProv",
-            class_config=dict(tnVzOOBBrCPName=contract)
-        )
+        aci.payload(aci_class="mgmtRsOoBProv", class_config=dict(tnVzOOBBrCPName=contract))
+
         aci.get_diff(aci_class="mgmtRsOoBProv")
 
         aci.post_config()

--- a/plugins/modules/aci_oob_epg_to_contract.py
+++ b/plugins/modules/aci_oob_epg_to_contract.py
@@ -1,0 +1,256 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Eduardo Pozo <ep@devkom.no>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: aci_oob_epg_to_contract
+short_description: Manage out-of-band contract association with an out-of-band management EPG.
+description:
+- This module manages the contract association (mgmtRsOoBProv) under an out-of-band management EPG (mgmtOoB) within the Cisco ACI mgmt tenant.
+options:
+  epg:
+    description:
+    - The name of the out-of-band management EPG (under mgmtp-default) where the contract will be associated.
+    type: str
+    required: true
+  contract:
+    description:
+    - The name of the out-of-band contract to be provided by the management EPG.
+    type: str
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+
+extends_documentation_fragment:
+- cisco.aci.aci
+- cisco.aci.annotation
+
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC classes B(mgmt:OoB) and B(mgmt:InB).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+
+author:
+- Eduardo Pozo (@edudppaz)
+'''
+
+EXAMPLES = r'''
+- name: Associate contract to an out-of-band EPG
+  cisco.aci.aci_oob_epg_to_contract:
+    epg: default
+    contract: default
+    state: present
+  delegate_to: localhost
+
+- name: Query all contracts associated with an out-of-band EPG
+  cisco.aci.aci_oob_epg_to_contract:
+    epg: default
+    state: query
+  delegate_to: localhost
+
+- name: Query a specific contract association with an out-of-band EPG
+  cisco.aci.aci_oob_epg_to_contract:
+    epg: default
+    contract: default
+    state: query
+  delegate_to: localhost
+
+- name: Remove contract association from an out-of-band EPG
+  cisco.aci.aci_oob_epg_to_contract:
+    epg: default
+    contract: default
+    state: absent
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+   current:
+     description: The existing configuration from the APIC after the module has finished
+     returned: success
+     type: list
+     sample:
+       [
+           {
+               "fvTenant": {
+                   "attributes": {
+                       "descr": "Production environment",
+                       "dn": "uni/tn-production",
+                       "name": "production",
+                       "nameAlias": "",
+                       "ownerKey": "",
+                       "ownerTag": ""
+                   }
+               }
+           }
+       ]
+   error:
+     description: The error information as returned from the APIC
+     returned: failure
+     type: dict
+     sample:
+       {
+           "code": "122",
+           "text": "unknown managed object class foo"
+       }
+   raw:
+     description: The raw output returned by the APIC REST API (xml or json)
+     returned: parse error
+     type: str
+     sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class "/></imdata>'
+   sent:
+     description: The actual/minimal configuration pushed to the APIC
+     returned: info
+     type: list
+     sample:
+       {
+           "fvTenant": {
+               "attributes": {
+                   "descr": "Production environment"
+               }
+           }
+       }
+   previous:
+     description: The original configuration from the APIC before the module has started
+     returned: info
+     type: list
+     sample:
+       [
+           {
+               "fvTenant": {
+                   "attributes": {
+                       "descr": "Production",
+                       "dn": "uni/tn-production",
+                       "name": "production",
+                       "nameAlias": "",
+                       "ownerKey": "",
+                       "ownerTag": ""
+                   }
+               }
+           }
+       ]
+   proposed:
+     description: The assembled configuration from the user-provided parameters
+     returned: info
+     type: dict
+     sample:
+       {
+           "fvTenant": {
+               "attributes": {
+                   "descr": "Production environment",
+                   "name": "production"
+               }
+           }
+       }
+   filter_string:
+     description: The filter string used for the request
+     returned: failure or debug
+     type: str
+     sample: ?rsp-prop-include=config-only
+   method:
+     description: The HTTP method used for the request to the APIC
+     returned: failure or debug
+     type: str
+     sample: POST
+   response:
+     description: The HTTP response from the APIC
+     returned: failure or debug
+     type: str
+     sample: class_map (30 bytes)
+   status:
+     description: The HTTP status from the APIC
+     returned: failure or debug
+     type: int
+     sample: 200
+   url:
+     description: The HTTP url used for the request to the APIC
+     returned: failure or debug
+     type: str
+     sample: https://10.11.12.13/api/mo/uni/tn-production.json
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(aci_annotation_spec())
+    argument_spec.update(
+        epg=dict(type='str', required=True),
+        contract=dict(type='str'),
+        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ["state", "absent", ["epg", "contract"]],
+            ["state", "present", ["epg", "contract"]],
+        ],
+    )
+
+    epg = module.params['epg']
+    contract = module.params['contract']
+    state = module.params['state']
+
+    ctProv_mo = "uni/tn-mgmt/oobbrc-{0}".format(contract)
+
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class=dict(
+            aci_class="fvTenant",
+            aci_rn="tn-mgmt",
+            module_object="mgmt",
+            target_filter={"name": "mgmt"},
+        ),
+        subclass_1=dict(
+            aci_class="mgmtMgmtP",
+            aci_rn="mgmtp-default",
+            module_object="default",
+            target_filter={"name": "default"},
+        ),
+        subclass_2=dict(
+            aci_class="mgmtOoB",
+            aci_rn="oob-{0}".format(epg),
+            module_object=epg,
+            target_filter={"name": epg},
+        ),
+        subclass_3=dict(
+            aci_class="mgmtRsOoBProv",
+            aci_rn="rsooBProv-{0}".format(contract),
+            module_object=contract,
+            target_filter={"tDn": ctProv_mo},
+        ),
+    )
+
+    aci.get_existing()
+
+    if state == "present":
+        aci.payload(
+            aci_class="mgmtRsOoBProv",
+            class_config=dict(tnVzOOBBrCPName=contract)
+        )
+        aci.get_diff(aci_class="mgmtRsOoBProv")
+
+        aci.post_config()
+
+    elif state == "absent":
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aci_oob_epg_to_contract.py
+++ b/plugins/modules/aci_oob_epg_to_contract.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: aci_oob_epg_to_contract
 short_description: Manage out-of-band contract association with an out-of-band management EPG.
@@ -43,9 +43,9 @@ seealso:
 
 author:
 - Eduardo Pozo (@edudppaz)
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Associate contract to an out-of-band EPG
   cisco.aci.aci_oob_epg_to_contract:
     epg: default
@@ -72,9 +72,9 @@ EXAMPLES = r'''
     contract: default
     state: absent
   delegate_to: localhost
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
    current:
      description: The existing configuration from the APIC after the module has finished
      returned: success
@@ -177,7 +177,7 @@ RETURN = r'''
      returned: failure or debug
      type: str
      sample: https://10.11.12.13/api/mo/uni/tn-production.json
-'''
+"""
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec

--- a/plugins/modules/aci_oob_epg_to_contract.py
+++ b/plugins/modules/aci_oob_epg_to_contract.py
@@ -230,8 +230,8 @@ def main():
         subclass_3=dict(
             aci_class="mgmtRsOoBProv",
             aci_rn="rsooBProv-{0}".format(contract),
-            module_object=contract,
-            target_filter={"tDn": ctProv_mo},
+            module_object=ctProv_mo if contract else None,
+            target_filter={"tDn": ctProv_mo} if contract else {},
         ),
     )
 

--- a/tests/integration/targets/aci_oob_epg_to_contract/aliases
+++ b/tests/integration/targets/aci_oob_epg_to_contract/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_oob_epg_to_contract/tasks/main.yml
+++ b/tests/integration/targets/aci_oob_epg_to_contract/tasks/main.yml
@@ -1,0 +1,181 @@
+# Test code for the ACI module aci_oob_epg_to_contract
+# Copyright: (c) 2024, Eduardo Pozo (@edudppaz) <ep@devkom.no>
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    aci_info: &aci_info
+      host: '{{ aci_hostname }}'
+      username: '{{ aci_username }}'
+      password: '{{ aci_password }}'
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: '{{ aci_output_level | default("info") }}'
+
+- name: Verify Cloud and Non-Cloud Sites in use.
+  ansible.builtin.include_tasks: ../../../../../../integration/targets/aci_cloud_provider/tasks/main.yml
+
+- name: Execute tasks only for non-cloud sites
+  when: query_cloud.current == []  # This condition will execute only non-cloud sites
+  block:  # block specifies execution of tasks within, based on conditions
+  # CLEAN ENVIRONMENT
+  - name: Remove oob epg to contract association
+    cisco.aci.aci_oob_epg_to_contract: &contract_absent
+      <<: *aci_info
+      epg: module-testing-epg
+      contract: testing-contract
+      state: absent
+
+  # ADD CONTRACT TO OOB EPG
+  - name: Add provided contract to mgmt:OoB (check_mode)
+    cisco.aci.aci_oob_epg_to_contract: &contract_present
+      <<: *aci_info
+      epg: module-testing-epg
+      contract: testing-contract
+      state: present
+    check_mode: true
+    register: cm_add_contract
+
+  - name: Add provided contract to mgmt:OoB (normal mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_present
+    register: nm_add_contract
+
+  - name: Verify add_contract
+    ansible.builtin.assert:
+      that:
+      - cm_add_contract is changed
+      - nm_add_contract is changed
+      - cm_add_contract.proposed.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == nm_add_contract.proposed.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'testing-contract'
+      - cm_add_contract.current == cm_add_contract.previous == nm_add_contract.previous == []
+      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.annotation == 'orchestrator:ansible'
+      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-module-testing-epg/rsooBProv-testing-contract'
+      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'testing-contract'
+
+  - name: Add provided contract to mgmt:OoB again (check_mode) 
+    cisco.aci.aci_oob_epg_to_contract: *contract_present
+    check_mode: true
+    register: cm_add_contract_again
+
+  - name: Add provided contract to mgmt:OoB again (normal mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_present
+    register: nm_add_contract_again
+
+  - name: Verify add_contract_again
+    ansible.builtin.assert:
+      that:
+      - cm_add_contract_again is not changed
+      - nm_add_contract_again is not changed
+
+  # QUERY ALL CONTRACT
+  - name: Query all provided mgmt:OoB contracts (check_mode)
+    cisco.aci.aci_oob_epg_to_contract: &contract_query
+      <<: *aci_info
+      epg: module-testing-epg
+      state: query
+    check_mode: true
+    register: cm_query_all_contracts
+
+  - name: Query all provided mgmt:OoB contracts (normal mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_query
+    register: nm_query_all_contracts
+
+  - name: Verify query_all_contracts
+    ansible.builtin.assert:
+      that:
+      - cm_query_all_contracts is not changed
+      - nm_query_all_contracts is not changed
+      - cm_query_all_contracts == nm_query_all_contracts
+      - nm_query_all_contracts.current|length >= 1
+
+
+  # QUERY A CONTRACT
+  - name: Query a specific provided mgmt:OoB contract (check_mode)
+    cisco.aci.aci_oob_epg_to_contract:
+      <<: *contract_query
+      epg: module-testing-epg
+      contract: testing-contract
+    check_mode: true
+    register: cm_query_contract
+
+  - name: Query a specific provided mgmt:OoB contract (normal mode)
+    cisco.aci.aci_oob_epg_to_contract:
+      <<: *contract_query
+      epg: module-testing-epg
+      contract: testing-contract
+    register: nm_query_contract
+
+  - name: Verify query_contract
+    ansible.builtin.assert:
+      that:
+      - cm_query_contract is not changed
+      - nm_query_contract is not changed
+      - cm_query_contract == nm_query_contract
+      - nm_query_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-module-testing-epg/rsooBProv-testing-contract'
+      - nm_query_contract.current.0.mgmtRsOoBProv.attributes.tCl == 'vzOOBBrCP'
+      # - nm_query_contract.current.0.mgmtRsOoBProv.attributes.tDn == 'uni/tn-common/oobbrc-default'
+
+
+  # REMOVE CONTRACT
+  - name: Remove provided contract to mgmt:OoB (check_mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_absent
+    check_mode: true
+    register: cm_remove_contract
+
+  - name: Remove provided contract to mgmt:OoB (normal mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_absent
+    register: nm_remove_contract
+
+  - name: Verify remove_contract
+    ansible.builtin.assert:
+      that:
+      - cm_remove_contract is changed
+      - nm_remove_contract is changed
+      - cm_remove_contract.current.0.mgmtRsOoBProv.attributes.dn == cm_remove_contract.previous.0.mgmtRsOoBProv.attributes.dn == nm_remove_contract.previous.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-module-testing-epg/rsooBProv-testing-contract'
+      - cm_remove_contract.current.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == cm_remove_contract.previous.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == nm_remove_contract.previous.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'testing-contract'
+      - nm_remove_contract.current == []
+
+  - name: Remove provided contract to mgmt:OoB again (check_mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_absent
+    check_mode: true
+    register: cm_remove_contract_again
+
+  - name: Remove provided contract to mgmt:OoB again (normal mode)
+    cisco.aci.aci_oob_epg_to_contract: *contract_absent
+    register: nm_remove_contract_again
+
+  - name: Verify remove_contract_again
+    ansible.builtin.assert:
+      that:
+      - cm_remove_contract_again is not changed
+      - nm_remove_contract_again is not changed
+
+  # QUERY NON-EXISTING contract
+  - name: Query non-existing provided contract to mgmt:OoB (check_mode)
+    cisco.aci.aci_oob_epg_to_contract:
+      <<: *contract_query
+      epg: module-testing-epg
+      contract: testing-contract
+    check_mode: true
+    register: cm_query_non_contract
+
+  - name: Query non-existing provided contract to mgmt:OoB (normal mode)
+    cisco.aci.aci_oob_epg_to_contract:
+      <<: *contract_query
+      epg: module-testing-epg
+      contract: testing-contract
+    register: nm_query_non_contract
+
+  - name: Verify query_non_contract
+    ansible.builtin.assert:
+      that:
+      - cm_query_non_contract is not changed
+      - nm_query_non_contract is not changed
+      - cm_query_non_contract == nm_query_non_contract
+      - nm_query_non_contract.current == []

--- a/tests/integration/targets/aci_oob_epg_to_contract/tasks/main.yml
+++ b/tests/integration/targets/aci_oob_epg_to_contract/tasks/main.yml
@@ -29,16 +29,16 @@
   - name: Remove oob epg to contract association
     cisco.aci.aci_oob_epg_to_contract: &contract_absent
       <<: *aci_info
-      epg: module-testing-epg
-      contract: testing-contract
+      epg: default
+      contract: default
       state: absent
 
   # ADD CONTRACT TO OOB EPG
   - name: Add provided contract to mgmt:OoB (check_mode)
     cisco.aci.aci_oob_epg_to_contract: &contract_present
       <<: *aci_info
-      epg: module-testing-epg
-      contract: testing-contract
+      epg: default
+      contract: default
       state: present
     check_mode: true
     register: cm_add_contract
@@ -52,11 +52,11 @@
       that:
       - cm_add_contract is changed
       - nm_add_contract is changed
-      - cm_add_contract.proposed.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == nm_add_contract.proposed.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'testing-contract'
+      - cm_add_contract.proposed.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == nm_add_contract.proposed.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'default'
       - cm_add_contract.current == cm_add_contract.previous == nm_add_contract.previous == []
       - nm_add_contract.current.0.mgmtRsOoBProv.attributes.annotation == 'orchestrator:ansible'
-      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-module-testing-epg/rsooBProv-testing-contract'
-      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'testing-contract'
+      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-default/rsooBProv-default'
+      - nm_add_contract.current.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'default'
 
   - name: Add provided contract to mgmt:OoB again (check_mode) 
     cisco.aci.aci_oob_epg_to_contract: *contract_present
@@ -77,7 +77,7 @@
   - name: Query all provided mgmt:OoB contracts (check_mode)
     cisco.aci.aci_oob_epg_to_contract: &contract_query
       <<: *aci_info
-      epg: module-testing-epg
+      epg: default
       state: query
     check_mode: true
     register: cm_query_all_contracts
@@ -94,21 +94,20 @@
       - cm_query_all_contracts == nm_query_all_contracts
       - nm_query_all_contracts.current|length >= 1
 
-
   # QUERY A CONTRACT
   - name: Query a specific provided mgmt:OoB contract (check_mode)
     cisco.aci.aci_oob_epg_to_contract:
       <<: *contract_query
-      epg: module-testing-epg
-      contract: testing-contract
+      epg: default
+      contract: default
     check_mode: true
     register: cm_query_contract
 
   - name: Query a specific provided mgmt:OoB contract (normal mode)
     cisco.aci.aci_oob_epg_to_contract:
       <<: *contract_query
-      epg: module-testing-epg
-      contract: testing-contract
+      epg: default
+      contract: default
     register: nm_query_contract
 
   - name: Verify query_contract
@@ -117,7 +116,7 @@
       - cm_query_contract is not changed
       - nm_query_contract is not changed
       - cm_query_contract == nm_query_contract
-      - nm_query_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-module-testing-epg/rsooBProv-testing-contract'
+      - nm_query_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-default/rsooBProv-default'
       - nm_query_contract.current.0.mgmtRsOoBProv.attributes.tCl == 'vzOOBBrCP'
       # - nm_query_contract.current.0.mgmtRsOoBProv.attributes.tDn == 'uni/tn-common/oobbrc-default'
 
@@ -137,8 +136,8 @@
       that:
       - cm_remove_contract is changed
       - nm_remove_contract is changed
-      - cm_remove_contract.current.0.mgmtRsOoBProv.attributes.dn == cm_remove_contract.previous.0.mgmtRsOoBProv.attributes.dn == nm_remove_contract.previous.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-module-testing-epg/rsooBProv-testing-contract'
-      - cm_remove_contract.current.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == cm_remove_contract.previous.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == nm_remove_contract.previous.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'testing-contract'
+      - cm_remove_contract.current.0.mgmtRsOoBProv.attributes.dn == cm_remove_contract.previous.0.mgmtRsOoBProv.attributes.dn == nm_remove_contract.previous.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-default/rsooBProv-default'
+      - cm_remove_contract.current.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == cm_remove_contract.previous.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == nm_remove_contract.previous.0.mgmtRsOoBProv.attributes.tnVzOOBBrCPName == 'default'
       - nm_remove_contract.current == []
 
   - name: Remove provided contract to mgmt:OoB again (check_mode)
@@ -160,16 +159,16 @@
   - name: Query non-existing provided contract to mgmt:OoB (check_mode)
     cisco.aci.aci_oob_epg_to_contract:
       <<: *contract_query
-      epg: module-testing-epg
-      contract: testing-contract
+      epg: default
+      contract: default
     check_mode: true
     register: cm_query_non_contract
 
   - name: Query non-existing provided contract to mgmt:OoB (normal mode)
     cisco.aci.aci_oob_epg_to_contract:
       <<: *contract_query
-      epg: module-testing-epg
-      contract: testing-contract
+      epg: default
+      contract: default
     register: nm_query_non_contract
 
   - name: Verify query_non_contract

--- a/tests/integration/targets/aci_oob_epg_to_contract/tasks/main.yml
+++ b/tests/integration/targets/aci_oob_epg_to_contract/tasks/main.yml
@@ -118,8 +118,6 @@
       - cm_query_contract == nm_query_contract
       - nm_query_contract.current.0.mgmtRsOoBProv.attributes.dn == 'uni/tn-mgmt/mgmtp-default/oob-default/rsooBProv-default'
       - nm_query_contract.current.0.mgmtRsOoBProv.attributes.tCl == 'vzOOBBrCP'
-      # - nm_query_contract.current.0.mgmtRsOoBProv.attributes.tDn == 'uni/tn-common/oobbrc-default'
-
 
   # REMOVE CONTRACT
   - name: Remove provided contract to mgmt:OoB (check_mode)


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment

<!--- Thank you for keeping this note for the community --->

### Description
<!--- Please specify additional labels in the labels section if applicable to the issue.
Possible additional labels: new_module/new_plugin/documentation/feature --->

<!--- Please leave a helpful description of the feature request here. --->

Adds a new module for binding of out-of-band EPG to a provided contract. As the `aci_epg_to_contract` does not apply to OOB epgs

### New or Affected Module(s):

<!--- Please list the new or affected module(s). --->

* aci_oob_epg_to_contract

### APIC version and APIC Platform
Tested on:
* V 5.2(8e)  and on-prem
* All the cloud APICs in the network-integration tests

### Collection versions

* cisco.aci x.x.x

### References

<!---
Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests

Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? For example:

--->

* #0000