### PR TITLE
[docs] Remove reference in documentation to encap_mode in the encap variable description of aci_epg_to_domain module (DCNE-225)

### DIFF
--- a/plugins/modules/aci_epg_to_domain.py
+++ b/plugins/modules/aci_epg_to_domain.py
@@ -48,7 +48,7 @@ options:
     aliases: [ type ]
   encap:
     description:
-    - The VLAN encapsulation for the EPG when binding a VMM Domain with static C(encap_mode).
+    - The VLAN encapsulation for the EPG when binding a VMM Domain in static VLAN mode.
     - This acts as the secondary encap when using useg.
     - Accepted values range between C(1) and C(4096).
     type: int

--- a/plugins/modules/aci_epg_to_domain.py
+++ b/plugins/modules/aci_epg_to_domain.py
@@ -49,6 +49,7 @@ options:
   encap:
     description:
     - The VLAN encapsulation for the EPG when binding a VMM Domain in static VLAN mode.
+    - The VLAN mode in UI is set to static when O(encap) is not set.
     - This acts as the secondary encap when using useg.
     - Accepted values range between C(1) and C(4096).
     type: int


### PR DESCRIPTION
fixes #702 