### PR TITLE
[minor_change] Allow empty list on bgp and peer controls

### DIFF
--- a/plugins/modules/aci_l3out_bgp_peer.py
+++ b/plugins/modules/aci_l3out_bgp_peer.py
@@ -500,9 +500,10 @@ def main():
                 "dis-peer-as-check",
                 "nh-self",
                 "send-domain-path",
+                "",
             ],
         ),
-        peer_controls=dict(type="list", elements="str", choices=["bfd", "dis-conn-check"]),
+        peer_controls=dict(type="list", elements="str", choices=["bfd", "dis-conn-check", ""]),
         address_type_controls=dict(type="list", elements="str", choices=["af-ucast", "af-mcast"]),
         private_asn_controls=dict(
             type="list",


### PR DESCRIPTION
Allows an empty list to be sent on bgp and peer controls to unset al controls if previously set with Ansible.

Right now, if the operator sends "bfd" (for example) on peer_controls, there is no way of unsetting bfd without removing the whole bgp peer. Sending an empty list allows all settings to be unset, and this is the default and supported by ACI:

Example of setting no peer controls on ACI GUI:
```
method: POST
url: https://10.1.xxx.xx/api/node/mo/uni/tn-tn_cml/out-l3out_aci_out_FW/lnodep-l3out_aci_out_FW-NP/lifp-l3out_aci_out_FW-IP/rspathL3OutAtt-[topology/pod-1/protpaths-101-102/pathep-[VPC-101_102_4]]/peerP-[10.1.xxx.xx].json
payload{"bgpPeerP":{"attributes":{"dn":"uni/tn-tn_cml/out-l3out_aci_out_FW/lnodep-l3out_aci_out_FW-NP/lifp-l3out_aci_out_FW-IP/rspathL3OutAtt-[topology/pod-1/protpaths-101-102/pathep-[VPC-101_102_4]]/peerP-[10.1.xxx.xx]","peerCtrl":""},"children":[]}}
```