### PR TITLE
Add 'preference' attribute to aci_l3out_static_routes_nexthop (DCNE-303)

### DIFF
--- a/plugins/modules/aci_l3out_static_routes_nexthop.py
+++ b/plugins/modules/aci_l3out_static_routes_nexthop.py
@@ -50,7 +50,9 @@ options:
     type: str
   preference:
     description:
-    - The administrative preference value for the nexthop
+    - The administrative preference value for the nexthop.
+    - The APIC defaults to 0 when unset during creation.
+    - The value must be between 0 and 255.
     type: int
   state:
     description:

--- a/plugins/modules/aci_l3out_static_routes_nexthop.py
+++ b/plugins/modules/aci_l3out_static_routes_nexthop.py
@@ -48,6 +48,10 @@ options:
     description:
     - The nexthop for the prefix
     type: str
+  preference:
+    description:
+    - The administrative preference value for the nexthop
+    type: int
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -84,6 +88,7 @@ EXAMPLES = r"""
     node_id: 111
     prefix: 10.84.90.0/24
     nexthop: 10.1.1.1
+    preference: 1
     state: present
   delegate_to: localhost
 
@@ -249,6 +254,7 @@ def main():
         node_id=dict(type="int"),
         prefix=dict(type="str", aliases=["route"]),
         nexthop=dict(type="str"),
+        preference=dict(type="int"),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
     )
 
@@ -268,6 +274,7 @@ def main():
     node_id = module.params.get("node_id")
     prefix = module.params.get("prefix")
     nexthop = module.params.get("nexthop")
+    preference = module.params.get("preference")
     state = module.params.get("state")
 
     node_tdn = None
@@ -290,7 +297,7 @@ def main():
     aci.get_existing()
 
     if state == "present":
-        aci.payload(aci_class="ipNexthopP", class_config=dict(nhAddr=nexthop))
+        aci.payload(aci_class="ipNexthopP", class_config=dict(nhAddr=nexthop, pref=preference))
 
         aci.get_diff(aci_class="ipNexthopP")
 

--- a/tests/integration/targets/aci_l3out_static_routes_nexthop/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_static_routes_nexthop/tasks/main.yml
@@ -120,7 +120,7 @@
   - name: Verify default preference
     ansible.builtin.assert:
       that:
-      - add_nh_no_pref.is_changed
+      - add_nh_no_pref is changed
       - add_nh_no_pref.current.0.ipNexthopP.attributes.pref == '0'
 
   # QUERY ALL NHs

--- a/tests/integration/targets/aci_l3out_static_routes_nexthop/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_static_routes_nexthop/tasks/main.yml
@@ -76,6 +76,7 @@
     cisco.aci.aci_l3out_static_routes_nexthop:  &nh_present
       <<: *prefix_present
       nexthop: 1.1.1.1
+      preference: 1
     check_mode: true
     register: cm_add_nh
 
@@ -91,6 +92,7 @@
       - nm_add_nh is changed
       - cm_add_nh.previous == nm_add_nh.previous == []
       - cm_add_nh.sent.ipNexthopP.attributes.nhAddr == nm_add_nh.sent.ipNexthopP.attributes.nhAddr == '1.1.1.1'
+      - cm_add_nh.sent.ipNexthopP.attributes.pref == nm_add_nh.sent.ipNexthopP.attributes.pref == '1'
       - nm_add_nh.current.0.ipNexthopP.attributes.annotation == 'orchestrator:ansible'
 
   - name: Add nexthop  again, check if idempotency works
@@ -108,6 +110,18 @@
     cisco.aci.aci_l3out_static_routes_nexthop: 
       <<: *nh_present
       nexthop: 1.1.1.2
+
+  - name: Add another nexthop without preference
+    cisco.aci.aci_l3out_static_routes_nexthop: 
+      <<: *prefix_present
+      nexthop: 2.2.2.2
+    register: add_nh_no_pref
+
+  - name: Verify default preference
+    ansible.builtin.assert:
+      that:
+      - add_nh_no_pref.is_changed
+      - add_nh_no_pref.current.0.ipNexthopP.attributes.pref == '0'
 
   # QUERY ALL NHs
   - name: Query all nodes


### PR DESCRIPTION
## Summary

This PR adds a new attribute, `preference`, to the `aci_l3out_static_routes_nexthop` module, enabling the configuration of a preference value for next-hop IP addresses in static routes. This change addresses a common use case where routing preferences need to be explicitly set for better control over routing decisions.

## Changes

- Introduced the `preference` attribute to `aci_l3out_static_routes_nexthop`
- Added test cases for validating the new functionality

## Notes

- The `preference` attribute is optional. If omitted, the API will use the default value of `0`.
- Ensured backward compatibility by not altering existing functionality without a `preference` value.
