### PR TITLE
management network instance profile

### DIFF
--- a/plugins/modules/aci_management_network_instance_profile.py
+++ b/plugins/modules/aci_management_network_instance_profile.py
@@ -1,0 +1,311 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "certified"}
+
+DOCUMENTATION = r"""
+---
+module: aci_management_network_instance_profile
+short_description: Manage external management network instance profiles (mgmt:InstP).
+description:
+- Manage external management network instance profiles on Cisco ACI fabrics.
+options:
+  profile:
+    description:
+    - The name of the external management network instance profile.
+    type: str
+    aliases: [ name, profile_name ]
+  qos_class:
+    description:
+    - QoS priority class identifier.
+    - The APIC defaults to C(unspecified) when unset during creation.
+    type: str
+    aliases: [ qos, priority, prio ]
+    choices: [ level1, level2, level3, level4, level5, level6, unspecified ]
+  description:
+    description:
+    - The description for the external management network instance profile.
+    type: str
+    aliases: [ descr ]
+  subnets:
+    description:
+    - The list of subnets in CIDR format to associate with the external management network instance profile.
+    - When state is C(present), any existing subnets will be removed from the object if they are not present in this list.
+    type: list
+    elements: string
+    aliases: [ subnet_list, networks, network_list ]
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    type: str
+    choices: [ absent, present, query ]
+    default: present
+  name_alias:
+    description:
+    - The alias for the current object. This relates to the nameAlias field in ACI.
+    type: str
+extends_documentation_fragment:
+- cisco.aci.aci
+- cisco.aci.annotation
+
+seealso:
+- name: APIC Management Information Model reference
+  description: More information about the internal APIC class B(fv:Ctx).
+  link: https://developer.cisco.com/docs/apic-mim-ref/
+author:
+- Tim Cragg (@timcragg)
+"""
+
+EXAMPLES = r"""
+- name: Add a new external management network instance profile
+  cisco.aci.aci_management_network_instance_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    name: lab_network_inst_profile
+    subnets:
+      - "10.20.30.0/24"
+      - "192.168.10.0/24"
+    state: present
+  delegate_to: localhost
+
+- name: Remove an external management network instance profile
+  cisco.aci.aci_management_network_instance_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    name: lab_network_inst_profile
+    state: absent
+  delegate_to: localhost
+
+- name: Query an external management network instance profile
+  cisco.aci.aci_management_network_instance_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    name: lab_network_inst_profile
+    state: query
+  delegate_to: localhost
+  register: query_result
+
+- name: Query all external management network instance profiles
+  cisco.aci.aci_management_network_instance_profile:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    state: query
+  delegate_to: localhost
+  register: query_result
+"""
+
+RETURN = r"""
+current:
+  description: The existing configuration from the APIC after the module has finished
+  returned: success
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production environment",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+error:
+  description: The error information as returned from the APIC
+  returned: failure
+  type: dict
+  sample:
+    {
+        "code": "122",
+        "text": "unknown managed object class foo"
+    }
+raw:
+  description: The raw output returned by the APIC REST API (xml or json)
+  returned: parse error
+  type: str
+  sample: '<?xml version="1.0" encoding="UTF-8"?><imdata totalCount="1"><error code="122" text="unknown managed object class foo"/></imdata>'
+sent:
+  description: The actual/minimal configuration pushed to the APIC
+  returned: info
+  type: list
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment"
+            }
+        }
+    }
+previous:
+  description: The original configuration from the APIC before the module has started
+  returned: info
+  type: list
+  sample:
+    [
+        {
+            "fvTenant": {
+                "attributes": {
+                    "descr": "Production",
+                    "dn": "uni/tn-production",
+                    "name": "production",
+                    "nameAlias": "",
+                    "ownerKey": "",
+                    "ownerTag": ""
+                }
+            }
+        }
+    ]
+proposed:
+  description: The assembled configuration from the user-provided parameters
+  returned: info
+  type: dict
+  sample:
+    {
+        "fvTenant": {
+            "attributes": {
+                "descr": "Production environment",
+                "name": "production"
+            }
+        }
+    }
+filter_string:
+  description: The filter string used for the request
+  returned: failure or debug
+  type: str
+  sample: ?rsp-prop-include=config-only
+method:
+  description: The HTTP method used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: POST
+response:
+  description: The HTTP response from the APIC
+  returned: failure or debug
+  type: str
+  sample: OK (30 bytes)
+status:
+  description: The HTTP status from the APIC
+  returned: failure or debug
+  type: int
+  sample: 200
+url:
+  description: The HTTP url used for the request to the APIC
+  returned: failure or debug
+  type: str
+  sample: https://10.11.12.13/api/mo/uni/tn-production.json
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(aci_annotation_spec())
+    argument_spec.update(
+        profile=dict(type="str", aliases=["name", "profile_name"]),
+        qos_class=dict(type="str", aliases=["qos", "priority", "prio"], choices=["level1", "level2", "level3", "level4", "level5", "level6", "unspecified"]),
+        description=dict(type="str", aliases=["descr"]),
+        subnets=dict(type="list", elements="str", aliases=["subnet_list", "networks", "network_list"]),
+        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
+        name_alias=dict(type="str"),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ["state", "absent", ["profile"]],
+            ["state", "present", ["profile", "subnets"]],
+        ],
+    )
+
+    profile = module.params.get("profile")
+    qos_class = module.params.get("qos_class")
+    description = module.params.get("description")
+    subnets = module.params.get("subnets")
+    state = module.params.get("state")
+    name_alias = module.params.get("name_alias")
+
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class=dict(
+            aci_class="fvTenant",
+            aci_rn="tn-mgmt",
+            module_object="mgmt",
+            target_filter={"name": "mgmt"},
+        ),
+        subclass_1=dict(
+            aci_class="mgmtExtMgmtEntity",
+            aci_rn="extmgmt-default",
+            module_object="default",
+            target_filter={"name": "default"},
+        ),
+        subclass_2=dict(
+            aci_class="mgmtInstP",
+            aci_rn="instp-{0}".format(profile),
+            module_object=profile,
+            target_filter={"name": profile},
+        ),
+        child_classes=["mgmtSubnet", "mgmtRsOoBCons"],
+    )
+
+    aci.get_existing()
+
+    if state == "present":
+        child_configs = []
+        for subnet in subnets:
+            child_configs.append(dict(mgmtSubnet=dict(attributes=dict(ip=subnet))))
+        if isinstance(aci.existing, list) and len(aci.existing) > 0:
+            for child in aci.existing[0].get("mgmtInstP", {}).get("children", {}):
+                # Remove any existing subnet entries that are not in the requested subnet list
+                if child.get("mgmtSubnet") and child.get("mgmtSubnet").get("attributes").get("ip") not in subnets:
+                    child_configs.append(
+                        {
+                            "mgmtSubnet": {
+                                "attributes": {
+                                    "ip": child.get("mgmtSubnet").get("attributes").get("ip"),
+                                    "status": "deleted",
+                                }
+                            }
+                        }
+                    )
+
+        aci.payload(
+            aci_class="mgmtInstP",
+            class_config=dict(
+                descr=description,
+                name=profile,
+                nameAlias=name_alias,
+                prio=qos_class,
+            ),
+            child_configs=child_configs,
+        )
+
+        aci.get_diff(aci_class="mgmtInstP")
+
+        aci.post_config()
+
+    elif state == "absent":
+        aci.delete_config()
+
+    aci.exit_json()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aci_management_network_instance_profile/aliases
+++ b/tests/integration/targets/aci_management_network_instance_profile/aliases
@@ -1,0 +1,2 @@
+# No ACI simulator yet, so not enabled
+# unsupported

--- a/tests/integration/targets/aci_management_network_instance_profile/tasks/main.yml
+++ b/tests/integration/targets/aci_management_network_instance_profile/tasks/main.yml
@@ -1,0 +1,146 @@
+# Test code for the ACI modules
+# Copyright: (c) 2025, Tim Cragg (@timcragg)
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  ansible.builtin.fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+- name: Set vars
+  ansible.builtin.set_fact:
+    aci_info: &aci_info
+      host: "{{ aci_hostname }}"
+      username: "{{ aci_username }}"
+      password: "{{ aci_password }}"
+      validate_certs: '{{ aci_validate_certs | default(false) }}'
+      use_ssl: '{{ aci_use_ssl | default(true) }}'
+      use_proxy: '{{ aci_use_proxy | default(true) }}'
+      output_level: debug
+
+# CLEAN ENVIRONMENT
+- name: Remove Management Network Instance Profile
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    state: absent
+
+# ADD PROFILE
+- name: Create Management Network Instance Profile (check mode)
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    qos_class: unspecified
+    description: Ansible test profile
+    subnets:
+      - "10.20.30.0/24"
+      - "192.168.10.0/24"
+    state: present
+  check_mode: true
+  register: cm_add_profile
+
+- name: Create Management Network Instance Profile (normal mode)
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    qos_class: unspecified
+    description: Ansible test profile
+    subnets:
+      - "10.20.30.0/24"
+      - "192.168.10.0/24"
+    state: present
+  check_mode: false
+  register: nm_add_profile
+
+- name: Create Management Network Instance Profile again - test idempotence
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    qos_class: unspecified
+    description: Ansible test profile
+    subnets:
+      - "10.20.30.0/24"
+      - "192.168.10.0/24"
+    state: present
+  check_mode: false
+  register: nm_add_profile_again
+
+- name: Verify object creation
+  ansible.builtin.assert:
+    that:
+      - cm_add_profile is changed
+      - nm_add_profile is changed
+      - nm_add_profile.sent == cm_add_profile.sent
+      - nm_add_profile.current.0.mgmtInstP.attributes.name == "ans_network_inst_profile"
+      - nm_add_profile.current.0.mgmtInstP.attributes.prio == "unspecified"
+      - nm_add_profile.current.0.mgmtInstP.attributes.descr == "Ansible test profile"
+      - nm_add_profile.current.0.mgmtInstP.children.0.mgmtSubnet.attributes.ip in ["10.20.30.0/24", "192.168.10.0/24"]
+      - nm_add_profile.current.0.mgmtInstP.children.1.mgmtSubnet.attributes.ip in ["10.20.30.0/24", "192.168.10.0/24"]
+      - nm_add_profile_again is not changed
+
+# MODIFY PROFILE
+- name: Update Management Network Instance Profile
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    qos_class: level1
+    description: Updated Ansible test profile
+    subnets:
+      - "10.20.30.0/24"
+      - "192.168.11.0/24"
+    state: present
+  check_mode: false
+  register: update_profile
+
+- name: Verify object update
+  ansible.builtin.assert:
+    that:
+      - update_profile is changed
+      - update_profile.current.0.mgmtInstP.attributes.name == "ans_network_inst_profile"
+      - update_profile.current.0.mgmtInstP.attributes.prio == "level1"
+      - update_profile.current.0.mgmtInstP.attributes.descr == "Updated Ansible test profile"
+      - update_profile.current.0.mgmtInstP.children.0.mgmtSubnet.attributes.ip in ["10.20.30.0/24", "192.168.11.0/24"]
+      - update_profile.current.0.mgmtInstP.children.1.mgmtSubnet.attributes.ip in ["10.20.30.0/24", "192.168.11.0/24"]
+      - update_profile.current.0.mgmtInstP.children | length == 2
+
+# QUERY PROFILE
+- name: Query Management Network Instance Profile
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    state: query
+  register: query_profile
+
+- name: Verify object query
+  ansible.builtin.assert:
+    that:
+      - query_profile is not changed
+      - query_profile.current.0.mgmtInstP.attributes.name == "ans_network_inst_profile"
+      - query_profile.current.0.mgmtInstP.attributes.prio == "level1"
+      - query_profile.current.0.mgmtInstP.attributes.descr == "Updated Ansible test profile"
+      - query_profile.current.0.mgmtInstP.children.0.mgmtSubnet.attributes.ip in ["10.20.30.0/24", "192.168.11.0/24"]
+      - query_profile.current.0.mgmtInstP.children.1.mgmtSubnet.attributes.ip in ["10.20.30.0/24", "192.168.11.0/24"]
+      - query_profile.current.0.mgmtInstP.children | length == 2
+
+# DELETE PROFILE
+- name: Delete Management Network Instance Profile
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    state: absent
+  register: remove_profile
+
+- name: Delete Management Network Instance Profile again
+  cisco.aci.aci_management_network_instance_profile:
+    <<: *aci_info
+    name: ans_network_inst_profile
+    state: absent
+  register: remove_profile_again
+
+- name: Verify object removal
+  ansible.builtin.assert:
+    that:
+      - remove_profile is changed
+      - remove_profile.current == []
+      - remove_profile_again is not changed


### PR DESCRIPTION
This PR adds support for Management Network Instance Profile (mgmtInstP) objects, which can be found at "tenant > mgmt > External Management Network Instance Profiles" in the GUI. The module also supports configuration of the mgmtSubnet child objects - when state is set to present, any existing subnets that are not in the requested list of subnets are removed.