### PR TITLE
feat: Added aci_bulk_static_bindings_to_epgs module (DCNE-622)

### DIFF
--- a/plugins/modules/aci_bulk_static_binding_to_epg.py
+++ b/plugins/modules/aci_bulk_static_binding_to_epg.py
@@ -5,11 +5,15 @@
 # Copyright: (c) 2022, Sabari Jaganathan (@sajagana) <sajagana@cisco.com>
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, annotations
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "certified"}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -21,21 +25,25 @@ options:
   tenant:
     description:
     - Name of the tenant.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     aliases: [ tenant_name ]
   ap:
     description:
     - The name of the application profile.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     aliases: [ app_profile, app_profile_name ]
   epg:
     description:
     - The name of the end point group.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     aliases: [ epg_name ]
   description:
     description:
     - Description for the static path to EPG binding.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     aliases: [ descr ]
   encap_id:
@@ -43,6 +51,7 @@ options:
     - The encapsulation ID associating the C(epg) with the interface path.
     - This acts as the secondary C(encap_id) when using micro-segmentation.
     - Accepted values are any valid encap ID for specified encap, currently ranges between C(1) and C(4096).
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: int
     aliases: [ vlan, vlan_id ]
   primary_encap_id:
@@ -51,12 +60,14 @@ options:
       with the interface path when using micro-segmentation.
     - Accepted values are any valid encap ID for specified encap, currently ranges between C(1) and C(4096) and C(unknown).
     - C(unknown) is the default value and using C(unknown) disables the Micro-Segmentation.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     aliases: [ primary_vlan, primary_vlan_id ]
   deploy_immediacy:
     description:
     - The Deployment Immediacy of Static EPG on PC, VPC or Interface.
     - The APIC defaults to C(lazy) when unset during creation.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     choices: [ immediate, lazy ]
   interface_mode:
@@ -66,22 +77,41 @@ options:
     - Values C(access) and C(untagged) are identical.
     - Values C(regular), C(tagged) and C(trunk) are identical.
     - The APIC defaults to C(trunk) when unset during creation.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     choices: [ 802.1p, access, native, regular, tagged, trunk, untagged ]
     aliases: [ interface_mode_name, mode ]
   interface_type:
     description:
     - The type of interface for the static EPG deployment.
+    - Module level EPG attributes are mutually exclusive with the EPGs list.
     type: str
     choices: [ fex, port_channel, switch_port, vpc, fex_port_channel, fex_vpc ]
     default: switch_port
-  interface_configs:
+  epgs:
     description:
-    - List of interface configurations, elements in the form of a dictionary.
-    - Module level attributes will be overridden by the path level attributes.
+    - List of EPG configurations with elements in the form of a dictionary.
+    - Module level EPG attributes are mutually exclusive with this EPGs list.
+    - Attributes defined in this epgs list will be overridden by the path level attributes if provided.
+    - The Path Level attributes encap_id and primary_encap_id are ignored if the epgs list is used.
     type: list
     elements: dict
     suboptions:
+      tenant:
+        description:
+        - Name of the tenant.
+        type: str
+        aliases: [ tenant_name ]
+      ap:
+        description:
+        - The name of the application profile.
+        type: str
+        aliases: [ app_profile, app_profile_name ]
+      epg:
+        description:
+        - The name of the endpoint group.
+        type: str
+        aliases: [ epg_name ]
       description:
         description:
         - Description for the static path to EPG binding.
@@ -100,6 +130,59 @@ options:
           with the interface path when using micro-segmentation.
         - Accepted values are any valid encap ID for specified encap, currently ranges between C(1) and C(4096) and C(unknown).
         - C(unknown) is the default value and using C(unknown) disables the Micro-Segmentation.
+        type: str
+        aliases: [ primary_vlan, primary_vlan_id ]
+      deploy_immediacy:
+        description:
+        - The Deployment Immediacy of Static EPG on PC, VPC or Interface.
+        - The APIC defaults to C(lazy) when unset during creation.
+        type: str
+        choices: [ immediate, lazy ]
+      interface_mode:
+        description:
+        - Determines how layer 2 tags will be read from and added to frames.
+        - Values C(802.1p) and C(native) are identical.
+        - Values C(access) and C(untagged) are identical.
+        - Values C(regular), C(tagged) and C(trunk) are identical.
+        - The APIC defaults to C(trunk) when unset during creation.
+        type: str
+        choices: [ 802.1p, access, native, regular, tagged, trunk, untagged ]
+        aliases: [ interface_mode_name, mode ]
+      interface_type:
+        description:
+        - The type of interface for the static EPG deployment.
+        - Different interface types are not supported at this level.
+        type: str
+        choices: [ fex, port_channel, switch_port, vpc, fex_port_channel, fex_vpc ]
+        default: switch_port
+  interface_configs:
+    description:
+    - List of interface configurations, elements in the form of a dictionary.
+    - Module level attributes will be overridden by the path level attributes.
+    - The Path Level attributes encap_id and primary_encap_id are ignored if the epgs list is used.
+    type: list
+    elements: dict
+    suboptions:
+      description:
+        description:
+        - Description for the static path to EPG binding.
+        type: str
+        aliases: [ descr ]
+      encap_id:
+        description:
+        - The encapsulation ID associating the C(epg) with the interface path.
+        - This acts as the secondary C(encap_id) when using micro-segmentation.
+        - Accepted values are any valid encap ID for specified encap, currently ranges between C(1) and C(4096).
+        - This attribute will be ignored if the epgs list is used.
+        type: int
+        aliases: [ vlan, vlan_id ]
+      primary_encap_id:
+        description:
+        - Determines the primary encapsulation ID associating the C(epg)
+          with the interface path when using micro-segmentation.
+        - Accepted values are any valid encap ID for specified encap, currently ranges between C(1) and C(4096) and C(unknown).
+        - C(unknown) is the default value and using C(unknown) disables the Micro-Segmentation.
+        - This attribute will be ignored if the epgs list is used.
         type: str
         aliases: [ primary_vlan, primary_vlan_id ]
       deploy_immediacy:
@@ -179,6 +262,7 @@ author:
 - Bruno Calogero (@brunocalogero)
 - Marcel Zehnder (@maercu)
 - Sabari Jaganathan (@sajagana)
+- Andreas Graber (@andreasgraber)
 """
 
 EXAMPLES = r"""
@@ -284,6 +368,40 @@ EXAMPLES = r"""
         encap_id: 108
     state: absent
   delegate_to: localhost
+
+- name: Create list of interfaces using epgs list
+  cisco.aci.aci_bulk_static_binding_to_epg:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    epgs:
+      - tenant: accessport-code-cert
+        ap: accessport_code_app
+        epg: accessport_epg1
+        encap_id: 221
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        description: "First Binding"
+      - tenant: accessport-code-cert-2
+        ap: accessport_code_app_2
+        epg: accessport_epg2
+        encap_id: 221
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        description: "Second Binding"
+    interface_configs:
+      - interface: 1/7
+        leafs: 101
+        pod: 1
+      - interface: 1/7
+        leafs: 107
+        pod: 7
+      - interface: 1/8
+        leafs: 108
+        pod: 8
+        encap_id: 108
+    state: present
+  delegate_to: localhost
 """
 
 RETURN = r"""
@@ -323,7 +441,7 @@ raw:
 sent:
   description: The actual/minimal configuration pushed to the APIC
   returned: info
-  type: list
+  type: dict
   sample:
     {
         "fvTenant": {
@@ -352,9 +470,9 @@ previous:
         }
     ]
 proposed:
-  description: The assembled configuration from the user-provided parameters
+  description: The assembled configuration from the user-provided parameters. Dict for single EPG, List for multiple EPGs.
   returned: info
-  type: dict
+  type: raw
   sample:
     {
         "fvTenant": {
@@ -390,9 +508,14 @@ url:
   type: str
   sample: https://10.11.12.13/api/mo/uni/tn-production.json
 """
-
+import json
+from typing import Optional
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import (
+    ACIModule,
+    aci_argument_spec,
+    aci_annotation_spec,
+)
 
 INTERFACE_MODE_MAPPING = {
     "802.1p": "native",
@@ -416,10 +539,8 @@ INTERFACE_TYPE_MAPPING = {
 INTERFACE_STATUS_MAPPING = {"absent": "deleted"}
 
 
-def main():
-    argument_spec = aci_argument_spec()
-    argument_spec.update(aci_annotation_spec())
-    argument_spec.update(
+def aci_epg_spec():
+    return dict(
         tenant=dict(type="str", aliases=["tenant_name"]),
         ap=dict(type="str", aliases=["app_profile", "app_profile_name"]),
         epg=dict(type="str", aliases=["epg_name"]),
@@ -428,54 +549,80 @@ def main():
         primary_encap_id=dict(type="str", aliases=["primary_vlan", "primary_vlan_id"]),
         deploy_immediacy=dict(type="str", choices=["immediate", "lazy"]),
         interface_mode=dict(
-            type="str", choices=["802.1p", "access", "native", "regular", "tagged", "trunk", "untagged"], aliases=["interface_mode_name", "mode"]
+            type="str",
+            choices=[
+                "802.1p",
+                "access",
+                "native",
+                "regular",
+                "tagged",
+                "trunk",
+                "untagged",
+            ],
+            aliases=["interface_mode_name", "mode"],
         ),
-        interface_type=dict(type="str", default="switch_port", choices=["fex", "port_channel", "switch_port", "vpc", "fex_port_channel", "fex_vpc"]),
-        interface_configs=dict(
-            type="list",
-            elements="dict",
-            options=dict(
-                description=dict(type="str", aliases=["descr"]),
-                encap_id=dict(type="int", aliases=["vlan", "vlan_id"]),
-                primary_encap_id=dict(type="str", aliases=["primary_vlan", "primary_vlan_id"]),
-                deploy_immediacy=dict(type="str", choices=["immediate", "lazy"]),
-                interface_mode=dict(
-                    type="str", choices=["802.1p", "access", "native", "regular", "tagged", "trunk", "untagged"], aliases=["interface_mode_name", "mode"]
-                ),
-                interface_type=dict(type="str", choices=["fex", "port_channel", "switch_port", "vpc", "fex_port_channel", "fex_vpc"]),
-                pod_id=dict(type="int", required=True, aliases=["pod", "pod_number"]),
-                leafs=dict(type="list", elements="str", required=True, aliases=["leaves", "nodes", "paths", "switches"]),
-                interface=dict(type="str", required=True),
-                extpaths=dict(type="list", elements="str"),
-            ),
+        interface_type=dict(
+            type="str",
+            default="switch_port",
+            choices=[
+                "fex",
+                "port_channel",
+                "switch_port",
+                "vpc",
+                "fex_port_channel",
+                "fex_vpc",
+            ],
         ),
-        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
     )
 
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        supports_check_mode=True,
-        required_if=[
-            ["state", "absent", ["ap", "epg", "tenant", "interface_configs"]],
-            ["state", "present", ["ap", "epg", "tenant", "interface_configs"]],
-        ],
+
+def validate_bindings(
+    interface_configs: Optional[list[dict]],
+    aci: ACIModule,
+    module_interface_type: str,
+    epg_dn: str,
+    existing_epgs: list[dict],
+) -> dict[str, dict]:
+    static_paths_dn = [
+        f"{epg_dn}/rspathAtt-[{validate_static_path(aci, interface_config, module_interface_type)}]" for interface_config in interface_configs or []
+    ]
+    existing_bindings_object = {}
+    for epg in existing_epgs:
+        epg_children = epg.get("fvAEPg", {}).get("children", [])
+        for binding in epg_children:
+            t_dn = binding.get("fvRsPathAtt", {}).get("attributes", {}).get("tDn")
+            static_path_dn = f"{epg_dn}/rspathAtt-[{t_dn}]"
+            if static_path_dn in static_paths_dn:
+                existing_bindings_object[static_path_dn] = binding
+    return existing_bindings_object
+
+
+def validate_static_path(aci: ACIModule, interface_config: dict, module_interface_type: str = None) -> str:
+    pod_id = interface_config.get("pod_id")
+    interface = interface_config.get("interface")
+    extpaths = interface_config.get("extpaths")
+    interface_type = interface_config.get("interface_type") or module_interface_type or "switch_port"
+    if interface_type in ["fex", "fex_vpc", "fex_port_channel"] and extpaths is None:
+        aci.fail_json(msg="extpaths is required when interface_type is: {0}".format(interface_type))
+    leafs = validate_leafs(aci, interface_config.get("leafs"), interface_type)
+    extpaths = validate_ext_paths(
+        aci=aci,
+        extpaths_config=interface_config.get("extpaths"),
+        interface_type=interface_type,
     )
 
-    tenant = module.params.get("tenant")
-    ap = module.params.get("ap")
-    epg = module.params.get("epg")
-    module_description = module.params.get("description")
-    module_encap_id = module.params.get("encap_id")
-    module_primary_encap_id = module.params.get("primary_encap_id")
-    module_deploy_immediacy = module.params.get("deploy_immediacy")
-    module_interface_mode = module.params.get("interface_mode")
-    module_interface_type = module.params.get("interface_type")
-    interface_configs = module.params.get("interface_configs")
-    state = module.params.get("state")
+    static_path = INTERFACE_TYPE_MAPPING[interface_type].format(pod_id=pod_id, leafs=leafs, extpaths=extpaths, interface=interface)
+    return static_path
 
-    aci = ACIModule(module)
-    children = []
 
+def get_existing_epg_based(
+    aci: ACIModule,
+    ap: Optional[str],
+    epg: Optional[str],
+    interface_configs: Optional[list[dict]],
+    module_interface_type: str,
+    tenant: Optional[str],
+) -> dict:
     aci.construct_url(
         root_class=dict(
             aci_class="fvTenant",
@@ -497,105 +644,535 @@ def main():
         ),
         child_classes=["fvRsPathAtt"],
     )
-
     aci.get_existing()
+    if interface_configs:
+        # This Function is validating the existing Bindings and get back a helper dict in order to easy access the existing bindings
+        return validate_bindings(
+            interface_configs=interface_configs,
+            aci=aci,
+            module_interface_type=module_interface_type,
+            epg_dn=f"uni/tn-{tenant}/ap-{ap}/epg-{epg}",
+            existing_epgs=aci.existing,
+        )
+    else:
+        return dict()
 
-    if state == "present" or state == "absent":
+
+def get_existing_epgs_based(
+    aci: ACIModule,
+    epgs: list[dict],
+    interface_configs: Optional[list[dict]],
+) -> dict:
+    # Setting the Batch Size to 20 Interfaces, which could give max 81'880 bindings back which is still fine
+    BATCH_SIZE = 20
+
+    # Getting interface_types of the list of epgs and remove duplicates
+    interface_types = list(set([epg.get("interface_type", "switch_port") for epg in epgs]))
+
+    if len(interface_types) > 1:
+        aci.fail_json(msg=f"Different interface types are not supported on epgs level! Got {interface_types}")
+
+    epg_dict_existing_filtered = validate_epgs(aci, epgs)
+
+    static_paths = []
+    if interface_configs:
         for interface_config in interface_configs:
-            pod_id = interface_config.get("pod_id")
-            interface = interface_config.get("interface")
-            extpaths = interface_config.get("extpaths")
-
-            description = interface_config.get("description") or module_description
-            deploy_immediacy = interface_config.get("deploy_immediacy") or module_deploy_immediacy
-            interface_type = interface_config.get("interface_type") or module_interface_type
-            encap_id = interface_config.get("encap_id") or module_encap_id
-            primary_encap_id = interface_config.get("primary_encap_id") or module_primary_encap_id
-            interface_mode = interface_config.get("interface_mode") or module_interface_mode
-
-            if interface_type in ["fex", "fex_vpc", "fex_port_channel"] and extpaths is None:
-                aci.fail_json(msg="extpaths is required when interface_type is: {0}".format(interface_type))
-
-            # Process leafs, and support dash-delimited leafs
-            leafs = []
-            for leaf in interface_config.get("leafs"):
-                # Users are likely to use integers for leaf IDs, which would raise an exception when using the join method
-                leafs.extend(str(leaf).split("-"))
-            if len(leafs) == 1:
-                if interface_type in ["vpc", "fex_vpc"]:
-                    aci.fail_json(msg='A interface_type of "vpc" requires 2 leafs')
-                leafs = leafs[0]
-            elif len(leafs) == 2:
-                if interface_type not in ["vpc", "fex_vpc"]:
-                    aci.fail_json(msg='The interface_types "switch_port", "port_channel", and "fex" do not support using multiple leafs for a single binding')
-                leafs = "-".join(leafs)
-            else:
-                aci.fail_json(msg='The "leafs" parameter must not have more than 2 entries')
-
-            if extpaths is not None:
-                # Process extpaths, and support dash-delimited extpaths
-                extpaths = []
-                for extpath in interface_config.get("extpaths"):
-                    # Users are likely to use integers for extpaths IDs, which would raise an exception when using the join method
-                    extpaths.extend(str(extpath).split("-"))
-                if len(extpaths) == 1:
-                    if interface_type == "fex_vpc":
-                        aci.fail_json(msg='A interface_type of "fex_vpc" requires 2 extpaths')
-                    extpaths = extpaths[0]
-                elif len(extpaths) == 2:
-                    if interface_type != "fex_vpc":
-                        aci.fail_json(msg='The interface_types "fex" and "fex_port_channel" do not support using multiple extpaths for a single binding')
-                    extpaths = "-".join(extpaths)
-                else:
-                    aci.fail_json(msg='The "extpaths" parameter must not have more than 2 entries')
-
-            if encap_id is not None:
-                if encap_id not in range(1, 4097):
-                    aci.fail_json(msg="Valid VLAN assignments are from 1 to 4096")
-                encap_id = "vlan-{0}".format(encap_id)
-
-            if primary_encap_id is not None:
-                try:
-                    primary_encap_id = int(primary_encap_id)
-                    if isinstance(primary_encap_id, int) and primary_encap_id in range(1, 4097):
-                        primary_encap_id = "vlan-{0}".format(primary_encap_id)
-                    else:
-                        aci.fail_json(msg="Valid VLAN assignments are from 1 to 4096 or unknown.")
-                except Exception as e:
-                    if isinstance(primary_encap_id, str) and primary_encap_id != "unknown":
-                        aci.fail_json(msg="Valid VLAN assignments are from 1 to 4096 or unknown. %s" % e)
-
-            static_path = INTERFACE_TYPE_MAPPING[interface_type].format(pod_id=pod_id, leafs=leafs, extpaths=extpaths, interface=interface)
-
-            interface_mode = INTERFACE_MODE_MAPPING.get(interface_mode)
-
-            interface_status = INTERFACE_STATUS_MAPPING.get(state)
-
-            children.append(
-                dict(
-                    fvRsPathAtt=dict(
-                        attributes=dict(
-                            descr=description,
-                            encap=encap_id,
-                            primaryEncap=primary_encap_id,
-                            instrImedcy=deploy_immediacy,
-                            mode=interface_mode,
-                            tDn=static_path,
-                            status=interface_status,
-                        )
-                    )
+            static_paths.append(
+                validate_static_path(
+                    aci=aci,
+                    interface_config=interface_config,
+                    module_interface_type=interface_types[0],
                 )
             )
 
-        aci.payload(
-            aci_class="fvAEPg",
-            class_config=dict(),
-            child_configs=children,
+    existing_bindings = []
+    uri = "/api/class/fvRsPathAtt.json?rsp-prop-include=config-only"
+    if not aci.suppress_previous:
+        if len(static_paths) == 0:
+            existing_bindings = get_objects_from_aci(aci=aci, uri=uri)
+        else:
+            index = 0
+            while index < len(static_paths):
+                batch = static_paths[index : index + BATCH_SIZE]
+                joined_string = ",".join([f'eq(fvRsPathAtt.tDn,"{path}")' for path in batch])
+                filter_string = f"query-target-filter=or({joined_string})"
+
+                existing_bindings.extend(get_objects_from_aci(aci=aci, uri=f"{uri}&{filter_string}"))
+                index += BATCH_SIZE
+
+    existing_binding_objects = dict()
+    for binding in existing_bindings:
+        binding_attributes = binding["fvRsPathAtt"].get("attributes")
+        binding_dn = binding_attributes.get("dn")
+        epg_dn = binding_dn.split("/rspathAtt-")[0]
+        epg_existing = epg_dict_existing_filtered.get(epg_dn)
+        if epg_existing:
+            epg_children = epg_existing.get("fvAEPg").setdefault("children", [])
+            existing_binding_objects[binding_dn] = binding
+            # Remove dn of Path attributes as the dn is given on the epg parent, which reflects the normal aci behaviour
+            binding["fvRsPathAtt"]["attributes"].pop("dn")
+            epg_children.append(binding)
+        else:
+            # Binding is not related to a Queried EPG
+            continue
+    aci.existing = list(epg_dict_existing_filtered.values())
+    return existing_binding_objects
+
+
+def validate_epgs(aci, epgs) -> dict:
+    # This Function is checking if the EPGs are present in the Fabric and get back a helper dict for easy accessing
+    # the EPG Objects later on.
+    epg_list_existing = get_objects_from_aci(aci=aci, uri="/api/class/fvAEPg.json?rsp-prop-include=config-only")
+    epg_dict_existing = {epg.get("fvAEPg", {}).get("attributes", {}).get("dn"): epg for epg in epg_list_existing}
+
+    epg_dict_existing_filtered = dict()
+    for epg in epgs:
+        dn = f"uni/tn-{epg.get('tenant')}/ap-{epg.get('ap')}/epg-{epg.get('epg')}"
+        epg_existing = epg_dict_existing.get(dn)
+        if epg_existing:
+            epg_dict_existing_filtered[dn] = epg_existing
+        else:
+            aci.fail_json(msg=f"The EPG with DN {dn} is not present in the Fabric. Can't proceed!")
+    return epg_dict_existing_filtered
+
+
+def get_objects_from_aci(aci: ACIModule, uri: str):
+    response, info = aci.api_call(
+        method="GET",
+        url=f"{aci.base_url}{uri}",
+        data=None,
+        return_response=True,
+    )
+    if info.get("status") != 200:
+        try:
+            # APIC error
+            aci.response_json(info["body"])
+            aci.fail_json(msg="APIC Error {code}: {text}".format_map(aci.error))
+        except KeyError:
+            # Connection error
+            aci.fail_json(msg="Connection failed for {url}. {msg}".format_map(info))
+    try:
+        response_data = json.loads(response.read())
+    except AttributeError:
+        response_data = json.loads(info.get("body"))
+
+    return response_data["imdata"]
+
+
+def should_post_binding(binding_config: dict, existing_binding: dict, state: str) -> bool:
+    should_push = False
+    if state == "present" and existing_binding is None:
+        should_push = True
+    elif state == "present" and existing_binding is not None:
+        existing_attributes = existing_binding.get("fvRsPathAtt", {}).get("attributes", {})
+        new_attributes = binding_config.get("fvRsPathAtt", {}).get("attributes", {})
+        for key, value in new_attributes.items():
+            if existing_attributes.get(key, None) != value:
+                should_push = True
+    elif state == "absent" and existing_binding is not None:
+        should_push = True
+    return should_push
+
+
+def validate_ext_paths(aci: ACIModule, extpaths_config: Optional[list], interface_type: str) -> Optional[str]:
+    if extpaths_config is not None:
+        # Process extpaths, and support dash-delimited extpaths
+        extpaths = []
+        for extpath in extpaths_config:
+            # Users are likely to use integers for extpaths IDs, which would raise an exception when using the join method
+            extpaths.extend(str(extpath).split("-"))
+        if len(extpaths) == 1:
+            if interface_type == "fex_vpc":
+                aci.fail_json(msg='A interface_type of "fex_vpc" requires 2 extpaths')
+            extpaths = extpaths[0]
+        elif len(extpaths) == 2:
+            if interface_type != "fex_vpc":
+                aci.fail_json(msg='The interface_types "fex" and "fex_port_channel" do not support using multiple extpaths for a single binding')
+            extpaths = "-".join(extpaths)
+        else:
+            aci.fail_json(msg='The "extpaths" parameter must not have more than 2 entries')
+
+        return extpaths
+    return None
+
+
+def validate_leafs(aci: ACIModule, leafs_config: list, interface_type: str) -> str:
+    # Process leafs, and support dash-delimited leafs
+    leafs = []
+    for leaf in leafs_config:
+        # Users are likely to use integers for leaf IDs, which would raise an exception when using the join method
+        leafs.extend(str(leaf).split("-"))
+    if len(leafs) == 1:
+        if interface_type in ["vpc", "fex_vpc"]:
+            aci.fail_json(msg='An interface_type of "vpc" or "fex_vpc" requires 2 leafs')
+        leafs = leafs[0]
+    elif len(leafs) == 2:
+        if interface_type not in ["vpc", "fex_vpc"]:
+            aci.fail_json(msg='The interface_types "switch_port", "port_channel", and "fex" do not support using multiple leafs for a single binding')
+        leafs = "-".join(leafs)
+    else:
+        aci.fail_json(msg='The "leafs" parameter must not have more than 2 entries')
+    return leafs
+
+
+def validate_primary_encap_id(aci: ACIModule, primary_encap_id: str) -> str:
+    if primary_encap_id is not None:
+        try:
+            primary_encap_id = int(primary_encap_id)
+            if primary_encap_id in range(1, 4097):
+                primary_encap_id = "vlan-{0}".format(primary_encap_id)
+            else:
+                aci.fail_json(msg="Valid VLAN assignments are from 1 to 4096 or unknown.")
+        except ValueError as e:
+            if isinstance(primary_encap_id, str) and primary_encap_id != "unknown":
+                aci.fail_json(msg="Valid VLAN assignments are from 1 to 4096 or unknown. %s" % e)
+    return primary_encap_id
+
+
+def merge_binding_change_to_existing_config_dict(
+    config_children: list[dict],
+    tenant: str,
+    ap: str,
+    epg: str,
+    binding_tree_config: dict,
+    ap_config: dict,
+    epg_config: dict,
+):
+    tenant_existing = next(
+        (tenant_exist for tenant_exist in config_children if tenant_exist.get("fvTenant", {}).get("attributes", {}).get("name", None) == tenant),
+        None,
+    )
+    if tenant_existing is not None:
+        tenant_children = tenant_existing.get("fvTenant").get("children")
+        ap_existing = next(
+            (ap_exist for ap_exist in tenant_children if ap_exist.get("fvAp", {}).get("attributes", {}).get("name", None) == ap),
+            None,
         )
 
-        aci.get_diff(aci_class="fvAEPg")
+        if ap_existing is not None:
+            fv_ap_children = ap_existing.get("fvAp").get("children")
+            epg_existing = next(
+                (epg_exist for epg_exist in fv_ap_children if epg_exist.get("fvAEPg", {}).get("attributes", {}).get("name", None) == epg),
+                None,
+            )
 
-        aci.post_config()
+            if epg_existing is None:
+                fv_ap_children.append(epg_config)
+        else:
+            tenant_children.append(ap_config)
+
+    else:
+        config_children.append(binding_tree_config)
+
+
+def get_epgs_exit_values(
+    aci: ACIModule,
+    changed: bool,
+    check_mode: bool,
+    epgs: list[dict],
+    interface_configs: Optional[list[dict]],
+):
+    result = aci.result
+    result["proposed"] = aci.proposed
+    result["previous"] = aci.existing
+    result["sent"] = aci.config
+    result["mo"] = aci.config
+    result["status"] = aci.status
+    result["url"] = aci.url
+    result["response"] = aci.response
+    result["method"] = aci.method
+    result["filter_string"] = aci.filter_string
+    result["changed"] = changed
+    if aci.httpapi_logs is not None:
+        result["httpapi_logs"] = aci.httpapi_logs
+
+    if check_mode is True:
+        result["current"] = aci.existing
+        return
+
+    if aci.suppress_verification:
+        if changed or aci.suppress_previous:
+            result["current_verified"] = False
+            result["current"] = aci.proposed
+        else:
+            # existing already equals the previous
+            result["current_verified"] = True
+    elif changed is True:
+        get_existing_epgs_based(
+            aci=aci,
+            epgs=epgs,
+            interface_configs=interface_configs,
+        )
+        result["current"] = aci.existing
+    elif changed is False:
+        result["current"] = result["previous"]
+
+
+def validate_encap_id(aci: ACIModule, encap_id: int):
+    if encap_id is not None:
+        if encap_id not in range(1, 4097):
+            aci.fail_json(msg="Valid VLAN assignments are from 1 to 4096")
+        encap_id = "vlan-{0}".format(encap_id)
+    return encap_id
+
+
+def main():
+    argument_spec = aci_argument_spec()
+    argument_spec.update(aci_annotation_spec())
+    argument_spec.update(aci_epg_spec())
+    argument_spec.update(
+        epgs=dict(type="list", elements="dict", options=aci_epg_spec()),
+        interface_configs=dict(
+            type="list",
+            elements="dict",
+            options=dict(
+                description=dict(type="str", aliases=["descr"]),
+                encap_id=dict(type="int", aliases=["vlan", "vlan_id"]),
+                primary_encap_id=dict(type="str", aliases=["primary_vlan", "primary_vlan_id"]),
+                deploy_immediacy=dict(type="str", choices=["immediate", "lazy"]),
+                interface_mode=dict(
+                    type="str",
+                    choices=[
+                        "802.1p",
+                        "access",
+                        "native",
+                        "regular",
+                        "tagged",
+                        "trunk",
+                        "untagged",
+                    ],
+                    aliases=["interface_mode_name", "mode"],
+                ),
+                interface_type=dict(
+                    type="str",
+                    choices=[
+                        "fex",
+                        "port_channel",
+                        "switch_port",
+                        "vpc",
+                        "fex_port_channel",
+                        "fex_vpc",
+                    ],
+                ),
+                pod_id=dict(type="int", required=True, aliases=["pod", "pod_number"]),
+                leafs=dict(
+                    type="list",
+                    elements="str",
+                    required=True,
+                    aliases=["leaves", "nodes", "paths", "switches"],
+                ),
+                interface=dict(type="str", required=True),
+                extpaths=dict(type="list", elements="str"),
+            ),
+        ),
+        state=dict(type="str", default="present", choices=["absent", "present", "query"]),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ("tenant", "epgs"),
+            ("ap", "epgs"),
+            ("epg", "epgs"),
+            ("encap_id", "epgs"),
+            ("primary_encap_id", "epgs"),
+            ("interface_mode", "epgs"),
+            ("interface_type", "epgs"),
+            ("deploy_immediacy", "epgs"),
+            ("description", "epgs"),
+        ],
+        required_if=[
+            ["state", "absent", ["interface_configs"]],
+            ["state", "present", ["interface_configs"]],
+        ],
+    )
+
+    module_tenant = module.params.get("tenant")
+    module_ap = module.params.get("ap")
+    module_epg = module.params.get("epg")
+    epgs = module.params.get("epgs")
+    module_description = module.params.get("description")
+    module_encap_id = module.params.get("encap_id")
+    module_primary_encap_id = module.params.get("primary_encap_id")
+    module_deploy_immediacy = module.params.get("deploy_immediacy")
+    module_interface_mode = module.params.get("interface_mode")
+    module_interface_type = module.params.get("interface_type")
+    interface_configs = module.params.get("interface_configs")
+    state = module.params.get("state")
+    annotation = module.params.get("annotation")
+
+    aci = ACIModule(module)
+
+    if state in ["absent", "present"] and not module_epg and not epgs:
+        aci.fail_json(msg="Either 'epg' or 'epgs' must be provided when state is '%s'." % state)
+
+    config_children = []
+    config = dict(polUni=dict(attributes=dict(), children=config_children))
+
+    # Ensure Objects are created to avoid Warnings in the IDE
+    static_bindings = []
+    existing_binding_objects = {}
+
+    if module_epg or (state == "query" and not epgs):
+        # Case single EPG provided or a query without multiple EPG
+        existing_binding_objects = get_existing_epg_based(
+            aci=aci,
+            tenant=module_tenant,
+            ap=module_ap,
+            epg=module_epg,
+            interface_configs=interface_configs,
+            module_interface_type=module_interface_type,
+        )
+        # Transform single EPG into a list of one dictionary in order to reuse the same domain logic as for multiple EPG.
+        static_bindings = [
+            {
+                "tenant": module_tenant,
+                "ap": module_ap,
+                "epg": module_epg,
+                "description": module_description,
+                "encap_id": module_encap_id,
+                "primary_encap_id": module_primary_encap_id,
+                "deploy_immediacy": module_deploy_immediacy,
+                "interface_mode": module_interface_mode,
+                "interface_type": module_interface_type,
+            }
+        ]
+    elif epgs:
+        # Case multiple EPG provided
+        existing_binding_objects = get_existing_epgs_based(
+            aci=aci,
+            epgs=epgs,
+            interface_configs=interface_configs,
+        )
+        static_bindings = epgs
+        aci.proposed = []  # proposed is a List in case of multiple EPG provided
+
+    if state == "present" or state == "absent":
+        for binding in static_bindings:
+            tenant_inner = binding.get("tenant")
+            ap_inner = binding.get("ap")
+            epg_inner = binding.get("epg")
+
+            if tenant_inner is None or ap_inner is None or epg_inner is None:
+                aci.fail_json(msg=f"Tenant:{tenant_inner} AP:{ap_inner} EPG: {epg_inner} needs to be provided together!")
+
+            module_description_inner = binding.get("description")
+            module_encap_id_inner = binding.get("encap_id")
+            module_primary_encap_id_inner = binding.get("primary_encap_id")
+            module_deploy_immediacy_inner = binding.get("deploy_immediacy")
+            module_interface_mode_inner = binding.get("interface_mode")
+            module_interface_type_inner = binding.get("interface_type")
+
+            # List for the Static Bindings, this list will be used for the aci.proposed and aci.config part
+            epg_children_config = list()
+            epg_config = dict(fvAEPg=dict(attributes=dict(name=epg_inner), children=epg_children_config))
+            ap_config = dict(fvAp=dict(attributes=dict(name=ap_inner), children=[epg_config]))
+            binding_tree_config = dict(fvTenant=dict(attributes=dict(name=tenant_inner), children=[ap_config]))
+
+            if epgs:
+                # Ensure Proposed gets the dn attribute and the Config dict not. Both uses the same children List in
+                # order to get the Binding Changes
+                aci.proposed.append(
+                    dict(
+                        fvAEPg=dict(
+                            attributes=dict(
+                                dn=f"uni/tn-{tenant_inner}/ap-{ap_inner}/epg-{epg_inner}",
+                                name=epg_inner,
+                            ),
+                            children=epg_children_config,
+                        )
+                    )
+                )
+
+            for interface_config in interface_configs:
+                pod_id = interface_config.get("pod_id")
+                interface = interface_config.get("interface")
+                extpaths = interface_config.get("extpaths")
+
+                description = interface_config.get("description") or module_description_inner
+                deploy_immediacy = interface_config.get("deploy_immediacy") or module_deploy_immediacy_inner
+                interface_type = interface_config.get("interface_type") or module_interface_type_inner or "switch_port"
+                encap_id = interface_config.get("encap_id") or module_encap_id_inner
+                primary_encap_id = interface_config.get("primary_encap_id") or module_primary_encap_id_inner
+
+                interface_mode = interface_config.get("interface_mode") or module_interface_mode_inner
+
+                leafs = validate_leafs(aci=aci, leafs_config=interface_config.get("leafs"), interface_type=interface_type)
+
+                extpaths = validate_ext_paths(aci=aci, extpaths_config=extpaths, interface_type=interface_type)
+
+                encap_id = validate_encap_id(aci=aci, encap_id=encap_id)
+
+                primary_encap_id = validate_primary_encap_id(aci=aci, primary_encap_id=primary_encap_id)
+
+                static_path = INTERFACE_TYPE_MAPPING[interface_type].format(pod_id=pod_id, leafs=leafs, extpaths=extpaths, interface=interface)
+
+                interface_mode = INTERFACE_MODE_MAPPING.get(interface_mode)
+
+                interface_status = INTERFACE_STATUS_MAPPING.get(state)
+
+                existing_binding = existing_binding_objects.get(f"uni/tn-{tenant_inner}/ap-{ap_inner}/epg-{epg_inner}/rspathAtt-[{static_path}]")
+
+                attributes = dict(
+                    descr=description,
+                    encap=encap_id,
+                    primaryEncap=primary_encap_id,
+                    instrImedcy=deploy_immediacy,
+                    mode=interface_mode,
+                    tDn=static_path,
+                    annotation=annotation,
+                    status=interface_status,
+                )
+                # Remove None values
+                attributes = {k: v for k, v in attributes.items() if v is not None}
+                binding_config = dict(fvRsPathAtt=dict(attributes=attributes))
+
+                if (
+                    should_post_binding(
+                        binding_config=binding_config,
+                        existing_binding=existing_binding,
+                        state=state,
+                    )
+                    is True
+                ):
+                    epg_config.get("fvAEPg", {}).get("children").append(binding_config)
+                    merge_binding_change_to_existing_config_dict(
+                        config_children=config_children,
+                        tenant=tenant_inner,
+                        ap=ap_inner,
+                        epg=epg_inner,
+                        ap_config=ap_config,
+                        epg_config=epg_config,
+                        binding_tree_config=binding_tree_config,
+                    )
+
+        if module_epg:
+            aci.payload(
+                aci_class="fvAEPg",
+                class_config=dict(),
+                child_configs=epg_config.get("fvAEPg", {}).get("children", []),
+            )
+            aci.get_diff(aci_class="fvAEPg")
+            aci.post_config()
+        else:
+            aci.path = "api/node/mo/uni.json"
+            aci.url = "{0}/{1}".format(aci.base_url, aci.path)
+            aci.method = "POST"
+            changed = False
+            if config_children:
+                aci.config = config
+                changed = True
+                if module.check_mode is False:
+                    aci.api_call("POST", aci.url, json.dumps(aci.config))
+            get_epgs_exit_values(
+                aci=aci,
+                changed=changed,
+                check_mode=module.check_mode,
+                epgs=epgs,
+                interface_configs=interface_configs,
+            )
+            module.exit_json(**aci.result)
 
     aci.exit_json()
 

--- a/plugins/modules/aci_bulk_static_binding_to_epg.py
+++ b/plugins/modules/aci_bulk_static_binding_to_epg.py
@@ -687,11 +687,18 @@ def get_existing_epgs_based(
 
     existing_bindings = []
     uri = "/api/class/fvRsPathAtt.json?rsp-prop-include=config-only"
+    index = 0
     if not aci.suppress_previous:
         if len(static_paths) == 0:
-            existing_bindings = get_objects_from_aci(aci=aci, uri=uri)
+            epg_dns = list(epg_dict_existing_filtered.keys())
+            while index < len(epg_dns):
+                batch = epg_dns[index: index + BATCH_SIZE]
+                joined_string = ",".join([f'wcard(fvRsPathAtt.dn,"{epg_dn}")' for epg_dn in batch])
+                filter_string = f"query-target-filter=or({joined_string})"
+
+                existing_bindings.extend(get_objects_from_aci(aci=aci, uri=f"{uri}&{filter_string}"))
+                index += BATCH_SIZE
         else:
-            index = 0
             while index < len(static_paths):
                 batch = static_paths[index : index + BATCH_SIZE]
                 joined_string = ",".join([f'eq(fvRsPathAtt.tDn,"{path}")' for path in batch])

--- a/plugins/modules/aci_bulk_static_binding_to_epg.py
+++ b/plugins/modules/aci_bulk_static_binding_to_epg.py
@@ -693,7 +693,7 @@ def get_existing_epgs_based(
             epg_dns = list(epg_dict_existing_filtered.keys())
             while index < len(epg_dns):
                 batch = epg_dns[index: index + BATCH_SIZE]
-                joined_string = ",".join([f'wcard(fvRsPathAtt.dn,"{epg_dn}")' for epg_dn in batch])
+                joined_string = ",".join([f'wcard(fvRsPathAtt.dn,"{epg_dn}/rspathAtt-")' for epg_dn in batch])
                 filter_string = f"query-target-filter=or({joined_string})"
 
                 existing_bindings.extend(get_objects_from_aci(aci=aci, uri=f"{uri}&{filter_string}"))

--- a/plugins/modules/aci_bulk_static_binding_to_epg.py
+++ b/plugins/modules/aci_bulk_static_binding_to_epg.py
@@ -692,7 +692,7 @@ def get_existing_epgs_based(
         if len(static_paths) == 0:
             epg_dns = list(epg_dict_existing_filtered.keys())
             while index < len(epg_dns):
-                batch = epg_dns[index: index + BATCH_SIZE]
+                batch = epg_dns[index : index + BATCH_SIZE]
                 joined_string = ",".join([f'wcard(fvRsPathAtt.dn,"{epg_dn}/rspathAtt-")' for epg_dn in batch])
                 filter_string = f"query-target-filter=or({joined_string})"
 

--- a/tests/integration/targets/aci_bulk_static_binding_to_epg/tasks/main.yml
+++ b/tests/integration/targets/aci_bulk_static_binding_to_epg/tasks/main.yml
@@ -46,6 +46,64 @@
       <<: *ap_present
       epg: anstest
 
+  - name: Ensure anstest_second epg exists
+    cisco.aci.aci_epg: &epg_second_present
+      <<: *ap_present
+      epg: anstest_second
+
+  - name: Ensure anstest_second ap exists
+    cisco.aci.aci_ap: &ap_present_second
+      <<: *tenant_present
+      ap: anstest_second
+
+  - name: Ensure anstest_third epg exists
+    cisco.aci.aci_epg: &epg_third_present
+      <<: *ap_present_second
+      epg: anstest_third
+
+  - name: Ensure ansible_test_second tenant does not exists
+    cisco.aci.aci_tenant: &tenant_second_absent
+      <<: *aci_info
+      tenant: ansible_test_second
+      state: absent
+
+  - name: Ensure ansible_test_second tenant exists
+    cisco.aci.aci_tenant: &tenant_second_present
+      <<: *tenant_second_absent
+      state: present
+
+  - name: Ensure tenant second anstest ap exists
+    cisco.aci.aci_ap: &tenant_second_ap_second_present
+      <<: *tenant_second_present
+      ap: anstest
+
+  - name: Ensure tenant second anstest epg exists
+    cisco.aci.aci_epg: &tenant_second_epg_present
+      <<: *tenant_second_ap_second_present
+      epg: anstest
+
+  - name: Ensure additional static path exists
+    cisco.aci.aci_static_binding_to_epg: &aci_static_binding_to_epg_second_present
+      <<: *epg_second_present
+      interface_type: switch_port
+      pod: 1
+      leafs: 101
+      interface: '1/48'
+      encap_id: 108
+      deploy_immediacy: lazy
+      interface_mode: trunk
+
+  - name: Ensure additional static path exists
+    cisco.aci.aci_static_binding_to_epg: &aci_static_binding_to_tenant_second_epg_present
+      <<: *tenant_second_epg_present
+      interface_type: switch_port
+      pod: 1
+      leafs: 101
+      interface: '1/48'
+      encap_id: 109
+      deploy_immediacy: lazy
+      interface_mode: trunk
+
   - name: Add list of interfaces with check mode
     cisco.aci.aci_bulk_static_binding_to_epg: &cm_interfaces_present
       <<: *epg_present
@@ -287,7 +345,7 @@
   - name: Idempotency assertions check for remove list of interfaces with normal mode
     ansible.builtin.assert:
       that:
-        - idempotency_interfaces_absent is changed
+        - idempotency_interfaces_absent is not changed
         - "'children' not in idempotency_interfaces_absent.current.0.fvAEPg"
         - "'children' not in idempotency_interfaces_absent.previous.0.fvAEPg"
         - idempotency_interfaces_absent.current.0.fvAEPg.attributes.name == "anstest"
@@ -303,7 +361,7 @@
       interface_configs:
         - extpaths:
             - 1012
-          interface: 2/7
+          interface: PC-TEST
           leafs: 102
           pod: 2
     register: fex_port_channel_present
@@ -315,7 +373,7 @@
         - fex_port_channel_present.current.0.fvAEPg.children | length == 1
         - '"children" not in fex_port_channel_present.previous.0.fvAEPg'
         - fex_port_channel_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-222"
-        - fex_port_channel_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-2/paths-102/extpaths-1012/pathep-[2/7]"
+        - fex_port_channel_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-2/paths-102/extpaths-1012/pathep-[PC-TEST]"
         - fex_port_channel_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "fex_port_channel - interface created"
 
   - name: Remove fex_port_channel interfaces from anstest epg
@@ -332,7 +390,7 @@
         - "'children' not in fex_port_channel_absent.current.0.fvAEPg"
         - fex_port_channel_absent.previous.0.fvAEPg.attributes.name == "anstest"
         - fex_port_channel_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-222"
-        - fex_port_channel_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-2/paths-102/extpaths-1012/pathep-[2/7]"
+        - fex_port_channel_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-2/paths-102/extpaths-1012/pathep-[PC-TEST]"
 
   - name: Add fex_vpc interfaces to anstest epg
     cisco.aci.aci_bulk_static_binding_to_epg: &fex_vpc_present
@@ -346,7 +404,7 @@
         - extpaths:
             - 103
             - 104
-          interface: 3/7
+          interface: VPC-TEST
           leafs:
             - 103
             - 104
@@ -361,7 +419,7 @@
         - "'children' not in fex_vpc_present.previous.0.fvAEPg"
         - fex_vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "fex_vpc - interface created"
         - fex_vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-223"
-        - fex_vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-3/protpaths-103-104/extprotpaths-103-104/pathep-[3/7]"
+        - fex_vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-3/protpaths-103-104/extprotpaths-103-104/pathep-[VPC-TEST]"
 
   - name: Remove fex_vpc interfaces from anstest epg
     cisco.aci.aci_bulk_static_binding_to_epg:
@@ -377,7 +435,7 @@
         - "'children' not in fex_vpc_absent.current.0.fvAEPg"
         - fex_vpc_absent.previous.0.fvAEPg.attributes.name == "anstest"
         - fex_vpc_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-223"
-        - fex_vpc_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-3/protpaths-103-104/extprotpaths-103-104/pathep-[3/7]"
+        - fex_vpc_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-3/protpaths-103-104/extprotpaths-103-104/pathep-[VPC-TEST]"
 
   - name: Add vpc interfaces to anstest epg
     cisco.aci.aci_bulk_static_binding_to_epg: &vpc_present
@@ -388,7 +446,7 @@
       interface_type: vpc
       encap_id: 224
       interface_configs:
-        - interface: 4/7
+        - interface: VPC-TEST
           leafs:
             - 105
             - 106
@@ -405,7 +463,7 @@
         - "'children' not in vpc_present.previous.0.fvAEPg"
         - vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "vpc - interface created"
         - vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-224"
-        - vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-4/protpaths-105-106/pathep-[4/7]"
+        - vpc_present.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-4/protpaths-105-106/pathep-[VPC-TEST]"
 
   - name: Remove vpc interfaces from anstest epg
     cisco.aci.aci_bulk_static_binding_to_epg:
@@ -421,7 +479,7 @@
         - "'children' not in vpc_absent.current.0.fvAEPg"
         - vpc_absent.previous.0.fvAEPg.attributes.name == "anstest"
         - vpc_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-224"
-        - vpc_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-4/protpaths-105-106/pathep-[4/7]"
+        - vpc_absent.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-4/protpaths-105-106/pathep-[VPC-TEST]"
 
   - name: Query all interfaces before start module and path level check
     cisco.aci.aci_bulk_static_binding_to_epg:
@@ -750,12 +808,28 @@
     ignore_errors: true
     register: switch_port_primary_encap_id_not_unknown
 
+  - name: AP missing
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *tenant_present
+      epg: not_exist
+      interface_configs:
+        - interface_type: switch_port
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+          interface: 'ansible_test'
+          pod: 1
+          leafs:
+            - 101
+    ignore_errors: true
+    register: ap_missing
+
   - name: Negative assertions to check error messages
     ansible.builtin.assert:
       that:
-      - switch_port_no_leafs.msg == "missing required arguments{{':'}} leafs found in interface_configs"
-      - fex_vpc_no_extpaths.msg == "extpaths is required when interface_type is{{':'}} fex_vpc"
-      - fex_vpc_one_node.msg == "A interface_type of \"vpc\" requires 2 leafs"
+      - 'switch_port_no_leafs.msg == "missing required arguments: leafs found in interface_configs"'
+      - 'fex_vpc_no_extpaths.msg == "extpaths is required when interface_type is: fex_vpc"'
+      - fex_vpc_one_node.msg == "An interface_type of \"vpc\" or \"fex_vpc\" requires 2 leafs"
       - fex_vpc_one_extpaths.msg == "A interface_type of \"fex_vpc\" requires 2 extpaths"
       - switch_port_two_leafs.msg == "The interface_types \"switch_port\", \"port_channel\", and \"fex\" do not support using multiple leafs for a single binding"
       - switch_port_two_extpaths.msg == "The interface_types \"fex\" and \"fex_port_channel\" do not support using multiple extpaths for a single binding"
@@ -764,9 +838,1009 @@
       - switch_port_encap_id_too_high.msg == "Valid VLAN assignments are from 1 to 4096"
       - switch_port_primary_encap_id_too_high.msg == "Valid VLAN assignments are from 1 to 4096 or unknown."
       - switch_port_primary_encap_id_not_unknown.msg.startswith("Valid VLAN assignments are from 1 to 4096 or unknown. ")
+      - 'ap_missing.msg == "Tenant:ansible_test AP:None EPG: not_exist needs to be provided together!"'
+
+  - name: "Set anchor as variable"
+    set_fact:
+        epg_present: *epg_present
+        epg_second_present: *epg_second_present
+        epg_third_present: *epg_third_present
+        tenant_second_epg_present: *tenant_second_epg_present
+
+  - name: Add list of interfaces with epgs with check mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &cm_interfaces_present_with_epgs
+      <<: *aci_info
+      epgs: &epgs
+        - tenant: '{{ epg_present["tenant"] }}'
+          ap: '{{ epg_present["ap"] }}'
+          epg: '{{ epg_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+        - tenant: '{{ epg_second_present["tenant"] }}'
+          ap: '{{ epg_second_present["ap"] }}'
+          epg: '{{ epg_second_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 108
+        - tenant: '{{ tenant_second_epg_present["tenant"] }}'
+          ap: '{{ tenant_second_epg_present["ap"] }}'
+          epg: '{{ tenant_second_epg_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 109
+        - tenant: '{{ epg_third_present["tenant"] }}'
+          ap: '{{ epg_third_present["ap"] }}'
+          epg: '{{ epg_third_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 110
+      interface_configs:
+        - interface: 1/7
+          leafs: 101
+          pod: 1
+        - interface: 1/7
+          leafs: 107
+          pod: 7
+        - interface: 1/7
+          leafs: 108
+          pod: 8
+      state: present
+    check_mode: true
+    register: cm_interfaces_present_with_epgs
+
+  - name: Assertions check for add list of interfaces with epgs with check mode
+    ansible.builtin.assert:
+      that:
+        - cm_interfaces_present_with_epgs is changed
+        - cm_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - "'children' not in cm_interfaces_present_with_epgs.previous.0.fvAEPg"
+        - "'children' not in cm_interfaces_present_with_epgs.current.0.fvAEPg"
+
+  - name: Add list of interfaces with epgs with normal mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &nm_interfaces_present_with_epgs
+      <<: *cm_interfaces_present_with_epgs
+    register: nm_interfaces_present_with_epgs
+
+  - name: Assertions check for add list of interfaces with epgs with normal mode
+    ansible.builtin.assert:
+      that:
+        - nm_interfaces_present_with_epgs is changed
+        - nm_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - nm_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - nm_interfaces_present_with_epgs.current.1.fvAEPg.children | length == 3
+        - nm_interfaces_present_with_epgs.current.2.fvAEPg.children | length == 3
+        - nm_interfaces_present_with_epgs.current.3.fvAEPg.children | length == 3
+        - "'children' not in nm_interfaces_present_with_epgs.previous.0.fvAEPg"
+        - nm_interfaces_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == ""
+
+  - name: Add list of interfaces with epgs with normal mode - idempotency works
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *nm_interfaces_present_with_epgs
+    register: idempotency_interfaces_present_with_epgs
+
+  - name: Idempotency assertions check for add list of interfaces with epgs with normal mode
+    ansible.builtin.assert:
+      that:
+        - idempotency_interfaces_present_with_epgs is not changed
+        - idempotency_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - idempotency_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - idempotency_interfaces_present_with_epgs.current.1.fvAEPg.children | length == 3
+        - idempotency_interfaces_present_with_epgs.current.2.fvAEPg.children | length == 3
+        - idempotency_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - idempotency_interfaces_present_with_epgs.previous.1.fvAEPg.children | length == 3
+        - idempotency_interfaces_present_with_epgs.previous.2.fvAEPg.children | length == 3
+
+  - name: Update list of interfaces - description with check mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &cm_update_interfaces_present_with_epgs
+      <<: *nm_interfaces_present_with_epgs
+      epgs:
+        - tenant: '{{ epg_present["tenant"] }}'
+          ap: '{{ epg_present["ap"] }}'
+          epg: '{{ epg_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+          description: "Description set from epgs level attributes 107"
+        - tenant: '{{ epg_second_present["tenant"] }}'
+          ap: '{{ epg_second_present["ap"] }}'
+          epg: '{{ epg_second_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 108
+          description: "Description set from epgs level attributes 108"
+        - tenant: '{{ tenant_second_epg_present["tenant"] }}'
+          ap: '{{ tenant_second_epg_present["ap"] }}'
+          epg: '{{ tenant_second_epg_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 109
+          description: "Description set from epgs level attributes 109"
+    check_mode: true
+    register: cm_update_interfaces_present_with_epgs
+
+  - name: Assertions check for update list of interfaces - description with check mode
+    ansible.builtin.assert:
+      that:
+        - cm_update_interfaces_present_with_epgs is changed
+        - cm_update_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - cm_update_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - cm_update_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - cm_update_interfaces_present_with_epgs.previous.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - cm_update_interfaces_present_with_epgs.current.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - cm_update_interfaces_present_with_epgs.current.1.fvAEPg.children | length == 3
+        - cm_update_interfaces_present_with_epgs.previous.1.fvAEPg.children | length == 3
+        - cm_update_interfaces_present_with_epgs.previous.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - cm_update_interfaces_present_with_epgs.current.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - cm_update_interfaces_present_with_epgs.current.2.fvAEPg.children | length == 3
+        - cm_update_interfaces_present_with_epgs.previous.2.fvAEPg.children | length == 3
+        - cm_update_interfaces_present_with_epgs.previous.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - cm_update_interfaces_present_with_epgs.current.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+
+  - name: Update list of interfaces - description with normal mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &nm_update_interfaces_present_with_epgs
+      <<: *cm_update_interfaces_present_with_epgs
+    register: nm_update_interfaces_present_with_epgs
+
+  - name: Assertions check for update list of interfaces - description with normal mode
+    ansible.builtin.assert:
+      that:
+        - nm_update_interfaces_present_with_epgs is changed
+        - nm_update_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - nm_update_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - nm_update_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - nm_update_interfaces_present_with_epgs.previous.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - nm_update_interfaces_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+        - nm_update_interfaces_present_with_epgs.current.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+        - nm_update_interfaces_present_with_epgs.current.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+        - nm_update_interfaces_present_with_epgs.current.1.fvAEPg.children | length == 3
+        - nm_update_interfaces_present_with_epgs.previous.1.fvAEPg.children | length == 3
+        - nm_update_interfaces_present_with_epgs.previous.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - nm_update_interfaces_present_with_epgs.current.1.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 108"
+        - nm_update_interfaces_present_with_epgs.current.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 108"
+        - nm_update_interfaces_present_with_epgs.current.1.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 108"
+        - nm_update_interfaces_present_with_epgs.current.2.fvAEPg.children | length == 3
+        - nm_update_interfaces_present_with_epgs.previous.2.fvAEPg.children | length == 3
+        - nm_update_interfaces_present_with_epgs.previous.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == ""
+        - nm_update_interfaces_present_with_epgs.current.2.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 109"
+        - nm_update_interfaces_present_with_epgs.current.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 109"
+        - nm_update_interfaces_present_with_epgs.current.2.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 109"
+
+  - name: Update list of interfaces - description with normal mode - idempotency works
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *nm_update_interfaces_present_with_epgs
+    register: idempotency_nm_update_interfaces_present_with_epgs
+
+  - name: Idempotency assertions check for update list of interfaces - description with normal mode
+    ansible.builtin.assert:
+      that:
+        - idempotency_nm_update_interfaces_present_with_epgs is not changed
+        - idempotency_nm_update_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - idempotency_nm_update_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - idempotency_nm_update_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - idempotency_nm_update_interfaces_present_with_epgs.current.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+        - idempotency_nm_update_interfaces_present_with_epgs.previous.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+
+  - name: Update list of interfaces description using path level attributes with check mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &cm_path_update_interfaces_present_with_epgs
+      <<: *aci_info
+      epgs: *epgs
+      interface_configs:
+        - interface: 1/7
+          leafs: 101
+          pod: 1
+          description: "Description set from path level attributes"
+        - interface: 1/7
+          leafs: 107
+          pod: 7
+          description: "Description set from path level attributes"
+        - interface: 1/7
+          leafs: 108
+          pod: 8
+          description: "Description set from path level attributes"
+      state: present
+    check_mode: true
+    register: cm_path_update_interfaces_present_with_epgs
+
+  - name: Assertions check for update list of interfaces description using path level attributes with check mode
+    ansible.builtin.assert:
+      that:
+        - cm_path_update_interfaces_present_with_epgs is changed
+        - cm_path_update_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - cm_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - cm_path_update_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - cm_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+        - cm_path_update_interfaces_present_with_epgs.previous.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+        - cm_path_update_interfaces_present_with_epgs.current.1.fvAEPg.children | length == 3
+        - cm_path_update_interfaces_present_with_epgs.previous.1.fvAEPg.children | length == 3
+        - cm_path_update_interfaces_present_with_epgs.current.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 108"
+        - cm_path_update_interfaces_present_with_epgs.previous.1.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 108"
+        - cm_path_update_interfaces_present_with_epgs.current.2.fvAEPg.children | length == 3
+        - cm_path_update_interfaces_present_with_epgs.previous.2.fvAEPg.children | length == 3
+        - cm_path_update_interfaces_present_with_epgs.current.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 109"
+        - cm_path_update_interfaces_present_with_epgs.previous.2.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 109"
+        - cm_path_update_interfaces_present_with_epgs.sent.polUni.children.0.fvTenant.children.0.fvAp.children.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+
+  - name: Update list of interfaces description using path level attributes with normal mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &nm_path_update_interfaces_present_with_epgs
+      <<: *cm_path_update_interfaces_present_with_epgs
+    register: nm_path_update_interfaces_present_with_epgs
+
+  - name: Assertions check for update list of interfaces description using path level attributes with normal mode
+    ansible.builtin.assert:
+      that:
+        - nm_path_update_interfaces_present_with_epgs is changed
+        - nm_path_update_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - nm_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - nm_path_update_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - nm_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - nm_path_update_interfaces_present_with_epgs.previous.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from epgs level attributes 107"
+
+  - name: Update list of interfaces description using path level attributes with normal mode - idempotency works
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *nm_path_update_interfaces_present_with_epgs
+    register: idempotency_path_update_interfaces_present_with_epgs
+
+  - name: Idempotency assertions check for update list of interfaces description using path level attributes with normal mode
+    ansible.builtin.assert:
+      that:
+        - idempotency_path_update_interfaces_present_with_epgs is not changed
+        - idempotency_path_update_interfaces_present_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - idempotency_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children | length == 3
+        - idempotency_path_update_interfaces_present_with_epgs.previous.0.fvAEPg.children | length == 3
+        - idempotency_path_update_interfaces_present_with_epgs.previous.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.1.fvAEPg.children | length == 3
+        - idempotency_path_update_interfaces_present_with_epgs.previous.1.fvAEPg.children | length == 3
+        - idempotency_path_update_interfaces_present_with_epgs.previous.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.1.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.1.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.1.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.2.fvAEPg.children | length == 3
+        - idempotency_path_update_interfaces_present_with_epgs.previous.2.fvAEPg.children | length == 3
+        - idempotency_path_update_interfaces_present_with_epgs.previous.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.2.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.2.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - idempotency_path_update_interfaces_present_with_epgs.current.2.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+
+  - name: Query all interfaces of an EPG
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *aci_info
+      epgs:
+        - tenant: ansible_test
+          ap: anstest
+          epg: anstest
+      state: query
+    register: query_result_of_anstest_epg_with_epgs
+
+  - name: Assertions check for query all interfaces of an EPG
+    ansible.builtin.assert:
+      that:
+        - query_result_of_anstest_epg_with_epgs is not changed
+        - query_result_of_anstest_epg_with_epgs.current | length == 1
+        - query_result_of_anstest_epg_with_epgs.current.0.fvAEPg.children | length == 3
+        - query_result_of_anstest_epg_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - query_result_of_anstest_epg_with_epgs.current.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - query_result_of_anstest_epg_with_epgs.current.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+
+  - name: Remove list of interfaces with check mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &cm_interfaces_absent_with_epgs
+      <<: *cm_interfaces_present_with_epgs
+      state: absent
+    check_mode: true
+    register: cm_interfaces_absent_with_epgs
+
+  - name: Assertions check for remove list of interfaces with check mode
+    ansible.builtin.assert:
+      that:
+        - cm_interfaces_absent_with_epgs is changed
+        - cm_interfaces_absent_with_epgs.current.0.fvAEPg.children | length == 3
+        - cm_interfaces_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - cm_interfaces_absent_with_epgs.previous.0.fvAEPg.children | length == 3
+        - cm_interfaces_absent_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - cm_interfaces_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - cm_interfaces_absent_with_epgs.current.1.fvAEPg.children | length == 3
+        - cm_interfaces_absent_with_epgs.current.1.fvAEPg.attributes.name == "anstest_second"
+        - cm_interfaces_absent_with_epgs.previous.1.fvAEPg.children | length == 3
+        - cm_interfaces_absent_with_epgs.current.1.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - cm_interfaces_absent_with_epgs.previous.1.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - cm_interfaces_absent_with_epgs.current.2.fvAEPg.children | length == 3
+        - cm_interfaces_absent_with_epgs.current.2.fvAEPg.attributes.dn == "uni/tn-ansible_test_second/ap-anstest/epg-anstest"
+        - cm_interfaces_absent_with_epgs.previous.2.fvAEPg.children | length == 3
+        - cm_interfaces_absent_with_epgs.current.2.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - cm_interfaces_absent_with_epgs.previous.2.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+
+  - name: Remove list of interfaces with normal mode
+    cisco.aci.aci_bulk_static_binding_to_epg: &nm_interfaces_absent_with_epgs
+      <<: *cm_interfaces_absent_with_epgs
+    register: nm_interfaces_absent_with_epgs
+
+  - name: Assertions check for remove list of interfaces with normal mode
+    ansible.builtin.assert:
+      that:
+        - nm_interfaces_absent_with_epgs is changed
+        - "'children' not in nm_interfaces_absent_with_epgs.current.0.fvAEPg"
+        - "'children' not in nm_interfaces_absent_with_epgs.current.1.fvAEPg"
+        - "'children' not in nm_interfaces_absent_with_epgs.current.2.fvAEPg"
+        - nm_interfaces_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - nm_interfaces_absent_with_epgs.previous.0.fvAEPg.children | length == 3
+        - nm_interfaces_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - nm_interfaces_absent_with_epgs.previous.0.fvAEPg.children.1.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+        - nm_interfaces_absent_with_epgs.previous.0.fvAEPg.children.2.fvRsPathAtt.attributes.descr == "Description set from path level attributes"
+
+  - name: Remove list of interfaces with normal mode - idempotency works
+    cisco.aci.aci_bulk_static_binding_to_epg: &idempotency_interfaces_absent_with_epgs
+      <<: *nm_interfaces_absent_with_epgs
+    register: idempotency_interfaces_absent_with_epgs
+
+  - name: Idempotency assertions check for remove list of interfaces with normal mode
+    ansible.builtin.assert:
+      that:
+        - idempotency_interfaces_absent_with_epgs is not changed
+        - "'children' not in idempotency_interfaces_absent_with_epgs.current.0.fvAEPg"
+        - "'children' not in nm_interfaces_absent_with_epgs.current.1.fvAEPg"
+        - "'children' not in nm_interfaces_absent_with_epgs.current.2.fvAEPg"
+        - "'children' not in idempotency_interfaces_absent_with_epgs.previous.0.fvAEPg"
+        - idempotency_interfaces_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+
+  - name: Add fex_port_channel interfaces to anstest epg
+    cisco.aci.aci_bulk_static_binding_to_epg: &fex_port_channel_present_with_epgs
+      <<: *aci_info
+      epgs: &one_epg_in_list
+        - tenant: '{{ epg_present["tenant"] }}'
+          ap: '{{ epg_present["ap"] }}'
+          epg: '{{ epg_present["epg"] }}'
+      interface_configs:
+        - extpaths:
+            - 1012
+          interface: PC-TEST
+          leafs: 102
+          pod: 2
+          interface_mode: trunk
+          interface_type: fex_port_channel
+          deploy_immediacy: lazy
+          descr: fex_port_channel - interface created
+          encap_id: 222
+    register: fex_port_channel_present_with_epgs
+
+  - name: Assertions check for add fex_port_channel interfaces to anstest epg
+    ansible.builtin.assert:
+      that:
+        - fex_port_channel_present_with_epgs is changed
+        - fex_port_channel_present_with_epgs.current.0.fvAEPg.children | length == 1
+        - '"children" not in fex_port_channel_present_with_epgs.previous.0.fvAEPg'
+        - fex_port_channel_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-222"
+        - fex_port_channel_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-2/paths-102/extpaths-1012/pathep-[PC-TEST]"
+        - fex_port_channel_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "fex_port_channel - interface created"
+
+  - name: Add fex_port_channel interfaces to anstest epg - Check Idempotency
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_port_channel_present_with_epgs
+    register: fex_port_channel_present_with_epgs
+
+  - name: Assertions check for idempotency on add fex_port_channel interfaces to anstest epg the second time
+    ansible.builtin.assert:
+      that:
+        - fex_port_channel_present_with_epgs is not changed
+
+  - name: Remove fex_port_channel interfaces from anstest epg
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_port_channel_present_with_epgs
+      state: absent
+    register: fex_port_channel_absent_with_epgs
+
+  - name: Assertions check for remove fex_port_channel interfaces from anstest epg
+    ansible.builtin.assert:
+      that:
+        - fex_port_channel_absent_with_epgs is changed
+        - fex_port_channel_absent_with_epgs.previous.0.fvAEPg.children | length == 1
+        - "'children' not in fex_port_channel_absent_with_epgs.current.0.fvAEPg"
+        - fex_port_channel_absent_with_epgs.previous.0.fvAEPg.attributes.name == "anstest"
+        - fex_port_channel_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-222"
+        - fex_port_channel_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-2/paths-102/extpaths-1012/pathep-[PC-TEST]"
+
+  - name: Add fex_vpc interfaces to anstest epg
+    cisco.aci.aci_bulk_static_binding_to_epg: &fex_vpc_present_with_epgs
+      <<: *aci_info
+      epgs: *one_epg_in_list
+      interface_configs:
+        - extpaths:
+            - 103
+            - 104
+          interface: VPC-TEST
+          leafs:
+            - 103
+            - 104
+          pod: 3
+          interface_mode: trunk
+          interface_type: fex_vpc
+          deploy_immediacy: lazy
+          descr: fex_vpc - interface created
+          encap_id: 223
+    register: fex_vpc_present_with_epgs
+
+  - name: Assertions check for add fex_vpc interfaces to anstest epg
+    ansible.builtin.assert:
+      that:
+        - fex_vpc_present_with_epgs is changed
+        - fex_vpc_present_with_epgs.current.0.fvAEPg.children | length == 1
+        - "'children' not in fex_vpc_present_with_epgs.previous.0.fvAEPg"
+        - fex_vpc_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "fex_vpc - interface created"
+        - fex_vpc_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-223"
+        - fex_vpc_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-3/protpaths-103-104/extprotpaths-103-104/pathep-[VPC-TEST]"
+
+  - name: Remove fex_vpc interfaces from anstest epg
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_present_with_epgs
+      state: absent
+    register: fex_vpc_absent_with_epgs
+
+  - name: Assertions check for remove fex_vpc interfaces from anstest epg
+    ansible.builtin.assert:
+      that:
+        - fex_vpc_absent_with_epgs is changed
+        - fex_vpc_absent_with_epgs.previous.0.fvAEPg.children | length == 1
+        - "'children' not in fex_vpc_absent_with_epgs.current.0.fvAEPg"
+        - fex_vpc_absent_with_epgs.previous.0.fvAEPg.attributes.name == "anstest"
+        - fex_vpc_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-223"
+        - fex_vpc_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-3/protpaths-103-104/extprotpaths-103-104/pathep-[VPC-TEST]"
+
+  - name: Add vpc interfaces to anstest epg
+    cisco.aci.aci_bulk_static_binding_to_epg: &vpc_present_with_epgs
+      <<: *aci_info
+      epgs: *one_epg_in_list
+      interface_configs:
+        - interface: VPC-TEST
+          leafs:
+            - 105
+            - 106
+          pod: 4
+          extpaths:
+            - 1015
+          deploy_immediacy: lazy
+          descr: vpc - interface created
+          interface_mode: trunk
+          interface_type: vpc
+          encap_id: 224
+    register: vpc_present_with_epgs
+
+  - name: Assertions check for add vpc interfaces to anstest epg
+    ansible.builtin.assert:
+      that:
+        - vpc_present_with_epgs is changed
+        - vpc_present_with_epgs.current.0.fvAEPg.children | length == 1
+        - "'children' not in vpc_present_with_epgs.previous.0.fvAEPg"
+        - vpc_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "vpc - interface created"
+        - vpc_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-224"
+        - vpc_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-4/protpaths-105-106/pathep-[VPC-TEST]"
+
+  - name: Remove vpc interfaces from anstest epg
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *vpc_present_with_epgs
+      state: absent
+    register: vpc_absent_epgs
+
+  - name: Assertions check for remove vpc interfaces from anstest epg
+    ansible.builtin.assert:
+      that:
+        - vpc_absent_epgs is changed
+        - vpc_absent_epgs.previous.0.fvAEPg.children | length == 1
+        - "'children' not in vpc_absent_epgs.current.0.fvAEPg"
+        - vpc_absent_epgs.previous.0.fvAEPg.attributes.name == "anstest"
+        - vpc_absent_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-224"
+        - vpc_absent_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-4/protpaths-105-106/pathep-[VPC-TEST]"
+
+  - name: Query all interfaces before start module and path level check
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *aci_info
+      epgs: *one_epg_in_list
+      state: query
+    register: query_result_with_epgs
+
+  - name: Assertions check for query all interfaces before start module and path level check
+    ansible.builtin.assert:
+      that:
+        - query_result_with_epgs is not changed
+        - "'children' not in query_result_with_epgs.current.0.fvAEPg"
+        - query_result_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+
+  - name: Add an interface with epgs level attributes
+    cisco.aci.aci_bulk_static_binding_to_epg: &module_level_check_present_with_epgs
+      <<: *aci_info
+      epgs:
+        - tenant: '{{ epg_present["tenant"] }}'
+          ap: '{{ epg_present["ap"] }}'
+          epg: '{{ epg_present["epg"] }}'
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 108
+          primary_encap_id: unknown
+          description: "Epgs level test"
+          interface_type: switch_port
+      interface_configs:
+        - interface: 1/8
+          leafs: 108
+          pod: 8
+      state: present
+    register: module_level_check_with_epgs
+
+  - name: Assertions check for add an interface with module epgs attributes
+    ansible.builtin.assert:
+      that:
+        - module_level_check_with_epgs is changed
+        - module_level_check_with_epgs.current.0.fvAEPg.children | length == 1
+        - module_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-108"
+        - module_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.primaryEncap == "unknown"
+        - module_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-8/paths-108/pathep-[eth1/8]"
+        - module_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Epgs level test"
+        - module_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.instrImedcy == "lazy"
+        - module_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.mode == "regular"
+
+  - name: Remove an interface with epgs level attributes
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *module_level_check_present_with_epgs
+      state: absent
+    register: module_level_check_absent_with_epgs
+
+  - name: Assertions check for remove an interface with module level attributes
+    ansible.builtin.assert:
+      that:
+        - module_level_check_absent_with_epgs is changed
+        - "'children' not in module_level_check_absent.current.0.fvAEPg"
+        - module_level_check_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - module_level_check_absent_with_epgs.previous.0.fvAEPg.children | length == 1
+        - module_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-108"
+        - module_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.primaryEncap == "unknown"
+        - module_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Epgs level test"
+        - module_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-8/paths-108/pathep-[eth1/8]"
+
+  - name: Add an interface with path level attributes
+    cisco.aci.aci_bulk_static_binding_to_epg: &path_level_check_present_with_epgs
+      <<: *aci_info
+      epgs: *one_epg_in_list
+      interface_configs:
+        - interface_type: switch_port
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 109
+          description: "Path level test"
+          interface: 1/9
+          leafs: 109
+          pod: 9
+      state: present
+    register: path_level_check_with_epgs
+
+  - name: Assertions check for add an interface with path level attributes
+    ansible.builtin.assert:
+      that:
+        - path_level_check_with_epgs is changed
+        - path_level_check_with_epgs.current.0.fvAEPg.children | length == 1
+        - path_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-109"
+        - path_level_check_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-9/paths-109/pathep-[eth1/9]"
+
+  - name: Remove an interface with path level attributes
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *path_level_check_present_with_epgs
+      state: absent
+    register: path_level_check_absent_with_epgs
+
+  - name: Assertions check for remove an interface with path level attributes
+    ansible.builtin.assert:
+      that:
+        - path_level_check_absent_with_epgs is changed
+        - "'children' not in path_level_check_absent_with_epgs.current.0.fvAEPg"
+        - path_level_check_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - path_level_check_absent_with_epgs.previous.0.fvAEPg.children | length == 1
+        - path_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-109"
+        - path_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Path level test"
+        - path_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-9/paths-109/pathep-[eth1/9]"
+
+  - name: Add an interface encap_id with path and epgs level attributes
+    cisco.aci.aci_bulk_static_binding_to_epg: &path_and_module_encap_id_present_with_epgs
+      <<: *aci_info
+      epgs:
+        - tenant: '{{ epg_present["tenant"] }}'
+          ap: '{{ epg_present["ap"] }}'
+          epg: '{{ epg_present["epg"] }}'
+          encap_id: 108
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          description: "Path and Module level test"
+      interface_configs:
+        - interface: 1/7
+          leafs: 107
+          pod: 7
+          encap_id: 107
+          interface_type: switch_port
+      state: present
+    register: path_and_module_encap_id_present_with_epgs
+
+  - name: Assertions check for add an interface encap_id with path and module level attributes
+    ansible.builtin.assert:
+      that:
+        - path_and_module_encap_id_present_with_epgs is changed
+        - path_and_module_encap_id_present_with_epgs.current.0.fvAEPg.children | length == 1
+        - path_and_module_encap_id_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-107"
+        - path_and_module_encap_id_present_with_epgs.current.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-7/paths-107/pathep-[eth1/7]"
+
+  - name: Remove an interface encap_id with path and module level attributes
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *path_and_module_encap_id_present_with_epgs
+      state: absent
+    register: path_and_module_encap_id_absent_with_epgs
+
+  - name: Assertions check for remove an interface encap_id with path and module level attributes
+    ansible.builtin.assert:
+      that:
+        - path_and_module_encap_id_absent_with_epgs is changed
+        - "'children' not in path_and_module_encap_id_absent.current.0.fvAEPg"
+        - path_and_module_encap_id_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
+        - path_and_module_encap_id_absent_with_epgs.previous.0.fvAEPg.children | length == 1
+        - path_and_module_encap_id_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-107"
+        - path_and_module_encap_id_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.descr == "Path and Module level test"
+        - path_and_module_encap_id_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.tDn == "topology/pod-7/paths-107/pathep-[eth1/7]"
+
+  - name: Generate a Mass Config Var
+    ansible.builtin.set_fact:
+      mass_interface_configs: '{{ mass_interface_configs | default([]) + [new_interface] }}'
+    vars:
+      new_interface:
+        pod_id: 1
+        leafs: 101
+        interface_type: switch_port
+        interface: "1/{{ item }}"
+    with_sequence: start=1 end=25
+
+  - name: Add Mass Interfaces with suppress_verification
+    cisco.aci.aci_bulk_static_binding_to_epg: &nm_mass_interfaces_present_with_epgs
+      <<: *aci_info
+      epgs:
+        - tenant: '{{ epg_present["tenant"] }}'
+          ap: '{{ epg_present["ap"] }}'
+          epg: '{{ epg_present["epg"] }}'
+          encap_id: 108
+          interface_mode: trunk
+          deploy_immediacy: lazy
+      interface_configs: '{{ mass_interface_configs }}'
+      suppress_verification: true
+      state: present
+    register: mass_interfaces_present_with_epgs_suppress_verification
+
+  - name: Add Mass Interfaces with suppress_verification Idempotency
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *nm_mass_interfaces_present_with_epgs
+    register: mass_interfaces_present_with_epgs_idempotent_suppress_verification
+
+  - name: Assertions check for add an mass interface with suppress_verification
+    ansible.builtin.assert:
+      that:
+        - mass_interfaces_present_with_epgs_suppress_verification is changed
+        - mass_interfaces_present_with_epgs_suppress_verification.current.0.fvAEPg.children | length == 25
+        - mass_interfaces_present_with_epgs_suppress_verification.current_verified == false
+        - mass_interfaces_present_with_epgs_idempotent_suppress_verification.current_verified == true
+
+  - name: Add Mass Interfaces - Check Idempotency
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *nm_mass_interfaces_present_with_epgs
+      suppress_verification: false
+    register: mass_interfaces_idem_present_with_epgs
+
+  - name: Assertions check for add an mass interface Idempotency
+    ansible.builtin.assert:
+      that:
+        - mass_interfaces_idem_present_with_epgs is not changed
+        - mass_interfaces_idem_present_with_epgs.current.0.fvAEPg.children | length == 25
+
+  - name: Bind static-binding to epg - interface type switch_port - no leafs (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      epgs: *one_epg_in_list
+      interface_configs:
+      - interface_type: switch_port
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        pod: 1
+      state: present
+    ignore_errors: true
+    register: switch_port_no_leafs_with_epgs
+
+  - name: Bind static-binding to epg - interface type fex_vpc - no extpaths (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg: &fex_vpc_no_extpaths_with_epgs
+      <<: *aci_info
+      epgs: *one_epg_in_list
+      interface_configs:
+      - interface_type: fex_vpc
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        leafs: 101
+        pod: 1
+      state: present
+    ignore_errors: true
+    register: fex_vpc_no_extpaths_with_epgs
+
+  - name: Bind static-binding to epg - interface type fex_vpc - incorrect extpaths (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: fex_vpc
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        leafs: 101
+        pod: 1
+        extpaths:
+        - 1012
+    ignore_errors: true
+    register: fex_vpc_one_node_with_epgs
+
+  - name: Bind static-binding to epg - fex_vpc with one extpaths (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: fex_vpc
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+        - 102
+        extpaths:
+        - 103
+    ignore_errors: true
+    register: fex_vpc_one_extpaths_with_epgs
+
+  - name: Bind static-binding to epg - switch_port with two leafs (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: switch_port
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+        - 102
+    ignore_errors: true
+    register: switch_port_two_leafs_with_epgs
+
+  - name: Bind static-binding to epg - switch_port with two extpaths (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: switch_port
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+        extpaths:
+        - 102
+        - 103
+    ignore_errors: true
+    register: switch_port_two_extpaths_with_epgs
+
+  - name: Bind static-binding to epg - fex_vpc with 3 nodes (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: fex_vpc
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+        - 102
+        - 103
+        extpaths:
+        - 101
+        - 102
+    ignore_errors: true
+    register: fex_vpc_three_leafs_with_epgs
+
+  - name: Bind static-binding to epg - fex_vpc with 3 expaths (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: fex_vpc
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+        - 102
+        extpaths:
+        - 101
+        - 102
+        - 103
+    ignore_errors: true
+    register: fex_vpc_three_expaths_with_epgs
+
+  - name: Bind static-binding to epg - switch_port with encap_id 5000 (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: switch_port
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 5000
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+    ignore_errors: true
+    register: switch_port_encap_id_too_high_with_epgs
+
+  - name: Bind static-binding to epg - switch_port with primary_encap_id 5000 (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: switch_port
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        primary_encap_id: 5000
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+    ignore_errors: true
+    register: switch_port_primary_encap_id_too_high_with_epgs
+
+  - name: Bind static-binding to epg - switch_port with primary_encap_id 5000 (normal mode)
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *fex_vpc_no_extpaths_with_epgs
+      interface_configs:
+      - interface_type: switch_port
+        interface_mode: trunk
+        deploy_immediacy: lazy
+        encap_id: 107
+        primary_encap_id: not_unknown
+        interface: 'ansible_test'
+        pod: 1
+        leafs:
+        - 101
+    ignore_errors: true
+    register: switch_port_primary_encap_id_not_unknown_with_epgs
+
+  - name: Single EPG and EPGs together
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *aci_info
+      tenant: test
+      ap: test
+      epg: test
+      epgs:
+        - tenant: test
+          ap: test
+          epg: test
+      interface_configs:
+        - interface_type: switch_port
+          interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+          primary_encap_id: not_unknown
+          interface: 1/10
+          pod: 1
+          leafs: 101
+    ignore_errors: true
+    register: single_epg_and_epgs_together
+
+  - name: Different Interface Types at EPGs Level
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *aci_info
+      epgs:
+        - tenant: test
+          ap: test
+          epg: test
+          interface_type: vpc
+        - tenant: test2
+          ap: test2
+          epg: test2
+          interface_type: switch_port
+      interface_configs:
+        - interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+          interface: 1/10
+          pod: 1
+          leafs: 101
+    ignore_errors: true
+    register: unsupported_interface_types
+
+  - name: EPG not present
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *aci_info
+      epgs:
+        - tenant: test_not_present
+          ap: test
+          epg: test
+      interface_configs:
+        - interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+          interface: 1/10
+          pod: 1
+          leafs: 101
+    ignore_errors: true
+    register: epg_not_present
+
+  - name: EPG nor EPGs
+    cisco.aci.aci_bulk_static_binding_to_epg:
+      <<: *aci_info
+      interface_configs:
+        - interface_mode: trunk
+          deploy_immediacy: lazy
+          encap_id: 107
+          interface: 1/10
+          pod: 1
+          leafs: 101
+    ignore_errors: true
+    register: epg_nor_epgs
+
+  - name: Negative assertions to check error messages
+    ansible.builtin.assert:
+      that:
+      - 'switch_port_no_leafs_with_epgs.msg == "missing required arguments: leafs found in interface_configs"'
+      - 'fex_vpc_no_extpaths_with_epgs.msg == "extpaths is required when interface_type is: fex_vpc"'
+      - fex_vpc_one_node_with_epgs.msg == "An interface_type of \"vpc\" or \"fex_vpc\" requires 2 leafs"
+      - fex_vpc_one_extpaths_with_epgs.msg == "A interface_type of \"fex_vpc\" requires 2 extpaths"
+      - switch_port_two_leafs_with_epgs.msg == "The interface_types \"switch_port\", \"port_channel\", and \"fex\" do not support using multiple leafs for a single binding"
+      - switch_port_two_extpaths_with_epgs.msg == "The interface_types \"fex\" and \"fex_port_channel\" do not support using multiple extpaths for a single binding"
+      - fex_vpc_three_leafs_with_epgs.msg == "The \"leafs\" parameter must not have more than 2 entries"
+      - fex_vpc_three_expaths_with_epgs.msg == "The \"extpaths\" parameter must not have more than 2 entries"
+      - switch_port_encap_id_too_high_with_epgs.msg == "Valid VLAN assignments are from 1 to 4096"
+      - switch_port_primary_encap_id_too_high_with_epgs.msg == "Valid VLAN assignments are from 1 to 4096 or unknown."
+      - switch_port_primary_encap_id_not_unknown_with_epgs.msg.startswith("Valid VLAN assignments are from 1 to 4096 or unknown. ")
+      - 'single_epg_and_epgs_together.msg == "parameters are mutually exclusive: tenant|epgs, ap|epgs, epg|epgs"'
+      - unsupported_interface_types.msg.startswith("Different interface types are not supported on epgs level! Got")
+      - '"The EPG with DN uni/tn-test_not_present/ap-test/epg-test is not present in the Fabric" in epg_not_present.msg'
+      - epg_nor_epgs.msg == "Either 'epg' or 'epgs' must be provided when state is 'present'."
+
+  - name: Ensure additional static path is still present exists
+    cisco.aci.aci_static_binding_to_epg:
+      <<: *aci_static_binding_to_epg_second_present
+      state: query
+    register: aci_static_binding_to_epg_second_present
+
+  - name: Assertions check for additional static path is still present exists
+    ansible.builtin.assert:
+      that:
+        - aci_static_binding_to_epg_second_present.current.0.fvRsPathAtt.attributes.dn == "uni/tn-ansible_test/ap-anstest/epg-anstest_second/rspathAtt-[topology/pod-1/paths-101/pathep-[eth1/48]]"
+
+  - name: Ensure additional static path is still present exists
+    cisco.aci.aci_static_binding_to_epg:
+      <<: *aci_static_binding_to_tenant_second_epg_present
+      state: query
+    register: aci_static_binding_to_tenant_second_epg_present
+
+  - name: Assertions check for additional static path is still present exists
+    ansible.builtin.assert:
+      that:
+        - aci_static_binding_to_tenant_second_epg_present.current.0.fvRsPathAtt.attributes.dn == "uni/tn-ansible_test_second/ap-anstest/epg-anstest/rspathAtt-[topology/pod-1/paths-101/pathep-[eth1/48]]"
 
   # Cleanup part
   - name: Remove anstest tenant
     cisco.aci.aci_tenant:
       <<: *tenant_present
+      state: absent
+
+  # Cleanup part
+  - name: Remove anstest_second tenant
+    cisco.aci.aci_tenant:
+      <<: *tenant_second_present
       state: absent

--- a/tests/integration/targets/aci_bulk_static_binding_to_epg/tasks/main.yml
+++ b/tests/integration/targets/aci_bulk_static_binding_to_epg/tasks/main.yml
@@ -1388,7 +1388,7 @@
     ansible.builtin.assert:
       that:
         - module_level_check_absent_with_epgs is changed
-        - "'children' not in module_level_check_absent.current.0.fvAEPg"
+        - "'children' not in module_level_check_absent_with_epgs.current.0.fvAEPg"
         - module_level_check_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
         - module_level_check_absent_with_epgs.previous.0.fvAEPg.children | length == 1
         - module_level_check_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-108"
@@ -1475,7 +1475,7 @@
     ansible.builtin.assert:
       that:
         - path_and_module_encap_id_absent_with_epgs is changed
-        - "'children' not in path_and_module_encap_id_absent.current.0.fvAEPg"
+        - "'children' not in path_and_module_encap_id_absent_with_epgs.current.0.fvAEPg"
         - path_and_module_encap_id_absent_with_epgs.current.0.fvAEPg.attributes.name == "anstest"
         - path_and_module_encap_id_absent_with_epgs.previous.0.fvAEPg.children | length == 1
         - path_and_module_encap_id_absent_with_epgs.previous.0.fvAEPg.children.0.fvRsPathAtt.attributes.encap == "vlan-107"


### PR DESCRIPTION
This PR enables configuration of trunk ports in one run. It is based on the already existing module aci_bulk_static_binding_to_epg.py. But in addition to that, the Goal is to push a list of EPGs to a list of interfaces. 

Some additional notes:

- The state: absent call is reporting always the changed = True. This is also the case aci_bulk_static_binding_to_epg. I guess this is due to some issues in the aci.py class (Recursion Stuff). Maybe needs to be addressed in a separate PR?
- If an EPG is not existing in ACI, the APIC automatically creates it during the execution of this bulk change. This is also the case with aci_bulk_static_binding_to_epg. I guess that's ok.
- If the Code is fine for You I can also add some integration tests for it.

Thanks for a review!