### PR TITLE
[ignore] Fix deletion example for aci_match_rule_destination to include the ip attribute and reorder the example to do delete after query (DCNE-639)

### DIFF
--- a/plugins/inventory/aci_inventory_system.py
+++ b/plugins/inventory/aci_inventory_system.py
@@ -57,7 +57,6 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.errors import AnsibleError
 from ansible.utils.display import Display
 
-
 display = Display()
 
 

--- a/plugins/modules/aci_aep_to_epg.py
+++ b/plugins/modules/aci_aep_to_epg.py
@@ -234,7 +234,6 @@ url:
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
 from ansible.module_utils.basic import AnsibleModule
 
-
 INTERFACE_MODE_MAPPING = {
     "802.1p": "native",
     "access": "untagged",

--- a/plugins/modules/aci_domain_to_encap_pool.py
+++ b/plugins/modules/aci_domain_to_encap_pool.py
@@ -239,7 +239,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
 from ansible_collections.cisco.aci.plugins.module_utils.constants import VM_PROVIDER_MAPPING
 
-
 POOL_MAPPING = dict(
     vlan=dict(
         aci_mo="uni/infra/vlanns-{0}",

--- a/plugins/modules/aci_fabric_node.py
+++ b/plugins/modules/aci_fabric_node.py
@@ -224,7 +224,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.constants import NODE_TYPE_MAPPING
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
 
-
 # NOTE: (This problem is also present on the APIC GUI)
 # NOTE: When specifying a C(role) the new Fabric Node Member will be created but Role on GUI will be "unknown", hence not what seems to be a module problem
 

--- a/plugins/modules/aci_interface_policy_leaf_policy_group.py
+++ b/plugins/modules/aci_interface_policy_leaf_policy_group.py
@@ -477,9 +477,9 @@ def main():
 
     aci = ACIModule(module)
     if lag_type == "leaf" and port_channel_policy is not None:
-        aci.fail_json("port_channel_policy is not a valid parameter for leaf\
- (leaf access port policy group), if used\
- assign null to it (port_channel_policy: null).")
+        aci.fail_json(
+            "port_channel_policy is not a valid parameter for leaf (leaf access port policy group), if used assign null to it (port_channel_policy: null)."
+        )
     invalid_parameters = {
         "transceiver_policy": "transceiver_policy is not a valid parameter for link/node (Port Channel, Virtual Port Channel),\
  if used assign null to it (transceiver_policy: null).",

--- a/plugins/modules/aci_interface_policy_leaf_policy_group.py
+++ b/plugins/modules/aci_interface_policy_leaf_policy_group.py
@@ -477,11 +477,9 @@ def main():
 
     aci = ACIModule(module)
     if lag_type == "leaf" and port_channel_policy is not None:
-        aci.fail_json(
-            "port_channel_policy is not a valid parameter for leaf\
+        aci.fail_json("port_channel_policy is not a valid parameter for leaf\
  (leaf access port policy group), if used\
- assign null to it (port_channel_policy: null)."
-        )
+ assign null to it (port_channel_policy: null).")
     invalid_parameters = {
         "transceiver_policy": "transceiver_policy is not a valid parameter for link/node (Port Channel, Virtual Port Channel),\
  if used assign null to it (transceiver_policy: null).",

--- a/plugins/modules/aci_interface_policy_mcp.py
+++ b/plugins/modules/aci_interface_policy_mcp.py
@@ -237,7 +237,6 @@ url:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec, aci_owner_spec
 
-
 MATCH_MCP_MODE_MAPPING = {"non_strict": "off", "strict": "on"}
 
 

--- a/plugins/modules/aci_match_route_destination.py
+++ b/plugins/modules/aci_match_route_destination.py
@@ -97,16 +97,6 @@ EXAMPLES = r"""
     state: present
   delegate_to: localhost
 
-- name: Delete a match rule destination
-  cisco.aci.aci_match_rule_destination:
-    host: apic
-    username: admin
-    password: SomeSecretPassword
-    match_rule: prod_match_rule
-    tenant: production
-    state: absent
-  delegate_to: localhost
-
 - name: Query all match rules destination
   cisco.aci.aci_match_rule_destination:
     host: apic
@@ -127,6 +117,17 @@ EXAMPLES = r"""
     state: query
   delegate_to: localhost
   register: query_result
+
+- name: Delete a match rule destination
+  cisco.aci.aci_match_rule_destination:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    match_rule: prod_match_rule
+    tenant: production
+    ip: 11.11.11.11/24
+    state: absent
+  delegate_to: localhost
 """
 
 RETURN = r"""

--- a/plugins/modules/aci_static_binding_to_epg.py
+++ b/plugins/modules/aci_static_binding_to_epg.py
@@ -372,10 +372,8 @@ def main():
             leafs = leafs[0]
         elif len(leafs) == 2:
             if interface_type not in ["vpc", "fex_vpc"]:
-                aci.fail_json(
-                    msg='The interface_types "switch_port", "port_channel", and "fex" \
-                    do not support using multiple leafs for a single binding'
-                )
+                aci.fail_json(msg='The interface_types "switch_port", "port_channel", and "fex" \
+                    do not support using multiple leafs for a single binding')
             leafs = "-".join(leafs)
         else:
             aci.fail_json(msg='The "leafs" parameter must not have more than 2 entries')
@@ -392,10 +390,8 @@ def main():
             extpaths = extpaths[0]
         elif len(extpaths) == 2:
             if interface_type != "fex_vpc":
-                aci.fail_json(
-                    msg='The interface_types "fex" \
-                    and "fex_port_channel" do not support using multiple extpaths for a single binding'
-                )
+                aci.fail_json(msg='The interface_types "fex" \
+                    and "fex_port_channel" do not support using multiple extpaths for a single binding')
             extpaths = "-".join(extpaths)
         else:
             aci.fail_json(msg='The "extpaths" parameter must not have more than 2 entries')

--- a/plugins/modules/aci_static_binding_to_epg.py
+++ b/plugins/modules/aci_static_binding_to_epg.py
@@ -372,8 +372,7 @@ def main():
             leafs = leafs[0]
         elif len(leafs) == 2:
             if interface_type not in ["vpc", "fex_vpc"]:
-                aci.fail_json(msg='The interface_types "switch_port", "port_channel", and "fex" \
-                    do not support using multiple leafs for a single binding')
+                aci.fail_json(msg='The interface_types "switch_port", "port_channel", and "fex" do not support using multiple leafs for a single binding')
             leafs = "-".join(leafs)
         else:
             aci.fail_json(msg='The "leafs" parameter must not have more than 2 entries')
@@ -390,8 +389,7 @@ def main():
             extpaths = extpaths[0]
         elif len(extpaths) == 2:
             if interface_type != "fex_vpc":
-                aci.fail_json(msg='The interface_types "fex" \
-                    and "fex_port_channel" do not support using multiple extpaths for a single binding')
+                aci.fail_json(msg='The interface_types "fex" and "fex_port_channel" do not support using multiple extpaths for a single binding')
             extpaths = "-".join(extpaths)
         else:
             aci.fail_json(msg='The "extpaths" parameter must not have more than 2 entries')

--- a/plugins/modules/aci_vzany_to_contract.py
+++ b/plugins/modules/aci_vzany_to_contract.py
@@ -218,7 +218,6 @@ url:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
 
-
 ACI_CLASS_MAPPING = dict(
     provider={"class": "vzRsAnyToProv", "rn": "rsanyToProv-", "target_attribute": "tnVzBrCPName"},
     consumer={"class": "vzRsAnyToCons", "rn": "rsanyToCons-", "target_attribute": "tnVzBrCPName"},

--- a/tests/unit/mock/path.py
+++ b/tests/unit/mock/path.py
@@ -5,5 +5,4 @@ __metaclass__ = type
 from ansible_collections.cisco.aci.tests.unit.compat.mock import MagicMock
 from ansible.utils.path import unfrackpath
 
-
 mock_unfrackpath_noop = MagicMock(spec_set=unfrackpath, side_effect=lambda x, *args, **kwargs: x)


### PR DESCRIPTION
fixes #824 