### PR TITLE
[minor_change] Allow query all objects by removing required attributes for query operations of aci_l3out_interface, aci_l3out_floating_svi, aci_l3out_floating_svi_path, aci_l3out_floating_svi_secondary_ip, aci_l3out_floating_svi_path_secondary_ip, aci_l3out_extsubnet (DCNE-714)

### DIFF
--- a/plugins/modules/aci_l3out_extsubnet.py
+++ b/plugins/modules/aci_l3out_extsubnet.py
@@ -21,19 +21,16 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
-    required: true
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
-    required: true
   extepg:
     description:
     - Name of an existing ExtEpg.
     type: str
     aliases: [ extepg_name ]
-    required: true
   network:
     description:
     - The network address for the Subnet.
@@ -261,9 +258,9 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        tenant=dict(type="str", required=True, aliases=["tenant_name"]),
-        l3out=dict(type="str", required=True, aliases=["l3out_name"]),
-        extepg=dict(type="str", required=True, aliases=["extepg_name"]),
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        extepg=dict(type="str", aliases=["extepg_name"]),
         network=dict(type="str", aliases=["address", "ip"]),
         description=dict(type="str", aliases=["descr"]),
         subnet_name=dict(type="str", aliases=["name"]),
@@ -277,8 +274,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["network"]],
-            ["state", "absent", ["network"]],
+            ["state", "present", ["tenant", "l3out", "extepg", "network"]],
+            ["state", "absent", ["tenant", "l3out", "extepg", "network"]],
         ],
         required_by={"aggregate": "scope"},
     )

--- a/plugins/modules/aci_l3out_floating_svi.py
+++ b/plugins/modules/aci_l3out_floating_svi.py
@@ -22,25 +22,21 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
-    required: true
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
-    required: true
   node_profile:
     description:
     - Name of the node profile.
     type: str
     aliases: [ node_profile_name, logical_node ]
-    required: true
   interface_profile:
     description:
     - Name of the interface profile.
     type: str
     aliases: [ interface_profile_name, logical_interface ]
-    required: true
   pod_id:
     description:
     - Pod ID to build the interface on.
@@ -324,10 +320,10 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        tenant=dict(type="str", aliases=["tenant_name"], required=True),
-        l3out=dict(type="str", aliases=["l3out_name"], required=True),
-        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"], required=True),
-        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"], required=True),
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"]),
+        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
         pod_id=dict(type="str"),
         node_id=dict(type="str"),
@@ -348,8 +344,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["pod_id", "node_id", "encap", "address"]],
-            ["state", "absent", ["pod_id", "node_id", "encap"]],
+            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "address"]],
+            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap"]],
         ],
     )
 

--- a/plugins/modules/aci_l3out_floating_svi_path.py
+++ b/plugins/modules/aci_l3out_floating_svi_path.py
@@ -346,7 +346,11 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "floating_ip"]],
+            [
+                "state",
+                "present",
+                ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "floating_ip"],
+            ],
             ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain"]],
         ],
     )

--- a/plugins/modules/aci_l3out_floating_svi_path.py
+++ b/plugins/modules/aci_l3out_floating_svi_path.py
@@ -22,40 +22,33 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
-    required: true
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
-    required: true
   node_profile:
     description:
     - Name of the node profile.
     type: str
     aliases: [ node_profile_name, logical_node ]
-    required: true
   interface_profile:
     description:
     - Name of the interface profile.
     type: str
     aliases: [ interface_profile_name, logical_interface ]
-    required: true
   pod_id:
     description:
     - Pod to build the interface on.
     type: str
-    required: true
   node_id:
     description:
     - Node to build the interface on for Port-channels and single ports.
     type: str
-    required: true
   encap:
     description:
     - Encapsulation on the interface (e.g. "vlan-500")
     type: str
-    required: true
   domain:
     description:
     - This option allows virtual machines to send frames with a mac address.
@@ -331,14 +324,14 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        tenant=dict(type="str", aliases=["tenant_name"], required=True),
-        l3out=dict(type="str", aliases=["l3out_name"], required=True),
-        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"], required=True),
-        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"], required=True),
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"]),
+        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
-        pod_id=dict(type="str", required=True),
-        node_id=dict(type="str", required=True),
-        encap=dict(type="str", required=True),
+        pod_id=dict(type="str"),
+        node_id=dict(type="str"),
+        encap=dict(type="str"),
         floating_ip=dict(type="str", aliases=["floating_address"]),
         forged_transmit=dict(type="str", choices=["enabled", "disabled"]),
         mac_change=dict(type="str", choices=["enabled", "disabled"]),
@@ -353,8 +346,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["domain_type", "domain", "floating_ip"]],
-            ["state", "absent", ["domain_type", "domain"]],
+            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "floating_ip"]],
+            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain"]],
         ],
     )
 
@@ -377,7 +370,9 @@ def main():
 
     aci = ACIModule(module)
 
-    node_dn = "topology/pod-{0}/node-{1}".format(pod_id, node_id)
+    node_dn = None
+    if pod_id and node_id:
+        node_dn = "topology/pod-{0}/node-{1}".format(pod_id, node_id)
 
     tDn = None
     if domain_type == "physical":

--- a/plugins/modules/aci_l3out_floating_svi_path_secondary_ip.py
+++ b/plugins/modules/aci_l3out_floating_svi_path_secondary_ip.py
@@ -301,8 +301,16 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "secondary_ip"]],
-            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "secondary_ip"]],
+            [
+                "state",
+                "absent",
+                ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "secondary_ip"],
+            ],
+            [
+                "state",
+                "present",
+                ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "secondary_ip"],
+            ],
         ],
     )
 

--- a/plugins/modules/aci_l3out_floating_svi_path_secondary_ip.py
+++ b/plugins/modules/aci_l3out_floating_svi_path_secondary_ip.py
@@ -26,51 +26,42 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
-    required: true
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
-    required: true
   node_profile:
     description:
     - Name of the node profile.
     type: str
     aliases: [ node_profile_name, logical_node ]
-    required: true
   interface_profile:
     description:
     - Name of the interface profile.
     type: str
     aliases: [ interface_profile_name, logical_interface ]
-    required: true
   pod_id:
     description:
     - Pod to build the interface on.
     type: str
-    required: true
   node_id:
     description:
     - Node to build the interface on for Port-channels and single ports.
     type: str
-    required: true
   encap:
     description:
     - Encapsulation on the interface (e.g. "vlan-500")
     type: str
-    required: true
   domain:
     description:
     - This option allows virtual machines to send frames with a mac address.
     type: str
-    required: true
   domain_type:
     description:
     - The domain type of the path.
     type: str
     choices: [ physical, vmware ]
-    required: true
   secondary_ip:
     description:
     - The secondary floating IP address.
@@ -293,16 +284,16 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        tenant=dict(type="str", aliases=["tenant_name"], required=True),
-        l3out=dict(type="str", aliases=["l3out_name"], required=True),
-        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"], required=True),
-        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"], required=True),
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"]),
+        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
-        pod_id=dict(type="str", required=True),
-        node_id=dict(type="str", required=True),
-        encap=dict(type="str", required=True),
-        domain_type=dict(type="str", choices=["physical", "vmware"], required=True),
-        domain=dict(type="str", required=True),
+        pod_id=dict(type="str"),
+        node_id=dict(type="str"),
+        encap=dict(type="str"),
+        domain_type=dict(type="str", choices=["physical", "vmware"]),
+        domain=dict(type="str"),
         secondary_ip=dict(type="str", aliases=["secondary_floating_address"]),
     )
 
@@ -310,8 +301,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "absent", ["secondary_ip"]],
-            ["state", "present", ["secondary_ip"]],
+            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "secondary_ip"]],
+            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "domain_type", "domain", "secondary_ip"]],
         ],
     )
 
@@ -329,12 +320,14 @@ def main():
 
     aci = ACIModule(module)
 
-    node_dn = "topology/pod-{0}/node-{1}".format(pod_id, node_id)
+    node_dn = None
+    if pod_id and node_id:
+        node_dn = "topology/pod-{0}/node-{1}".format(pod_id, node_id)
 
     tDn = None
     if domain_type == "physical":
         tDn = "uni/phys-{0}".format(domain)
-    else:
+    elif domain_type == "vmware":
         tDn = "uni/vmmp-VMware/dom-{0}".format(domain)
 
     aci.construct_url(

--- a/plugins/modules/aci_l3out_floating_svi_secondary_ip.py
+++ b/plugins/modules/aci_l3out_floating_svi_secondary_ip.py
@@ -26,40 +26,33 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
-    required: true
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
-    required: true
   node_profile:
     description:
     - Name of the node profile.
     type: str
     aliases: [ node_profile_name, logical_node ]
-    required: true
   interface_profile:
     description:
     - Name of the interface profile.
     type: str
     aliases: [ interface_profile_name, logical_interface ]
-    required: true
   pod_id:
     description:
     - Pod to build the interface on.
     type: str
-    required: true
   node_id:
     description:
     - Node to build the interface on for Port-channels and single ports.
     type: str
-    required: true
   encap:
     description:
     - Encapsulation on the interface (e.g. "vlan-500")
     type: str
-    required: true
   secondary_ip:
     description:
     - The secondary floating IP address.
@@ -273,14 +266,14 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        tenant=dict(type="str", aliases=["tenant_name"], required=True),
-        l3out=dict(type="str", aliases=["l3out_name"], required=True),
-        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"], required=True),
-        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"], required=True),
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"]),
+        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
-        pod_id=dict(type="str", required=True),
-        node_id=dict(type="str", required=True),
-        encap=dict(type="str", required=True),
+        pod_id=dict(type="str"),
+        node_id=dict(type="str"),
+        encap=dict(type="str"),
         secondary_ip=dict(type="str", aliases=["secondary_floating_address"]),
     )
 
@@ -288,8 +281,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "absent", ["secondary_ip"]],
-            ["state", "present", ["secondary_ip"]],
+            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "secondary_ip"]],
+            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "encap", "secondary_ip"]],
         ],
     )
 
@@ -305,7 +298,9 @@ def main():
 
     aci = ACIModule(module)
 
-    node_dn = "topology/pod-{0}/node-{1}".format(pod_id, node_id)
+    node_dn = None
+    if pod_id and node_id:
+        node_dn = "topology/pod-{0}/node-{1}".format(pod_id, node_id)
 
     aci.construct_url(
         root_class=dict(

--- a/plugins/modules/aci_l3out_interface.py
+++ b/plugins/modules/aci_l3out_interface.py
@@ -23,25 +23,21 @@ options:
     - Name of an existing tenant.
     type: str
     aliases: [ tenant_name ]
-    required: true
   l3out:
     description:
     - Name of an existing L3Out.
     type: str
     aliases: [ l3out_name ]
-    required: true
   node_profile:
     description:
     - Name of the node profile.
     type: str
     aliases: [ node_profile_name, logical_node ]
-    required: true
   interface_profile:
     description:
     - Name of the interface profile.
     type: str
     aliases: [ interface_profile_name, logical_interface ]
-    required: true
   pod_id:
     description:
     - Pod to build the interface on.
@@ -350,10 +346,10 @@ def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
     argument_spec.update(
-        tenant=dict(type="str", aliases=["tenant_name"], required=True),
-        l3out=dict(type="str", aliases=["l3out_name"], required=True),
-        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"], required=True),
-        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"], required=True),
+        tenant=dict(type="str", aliases=["tenant_name"]),
+        l3out=dict(type="str", aliases=["l3out_name"]),
+        node_profile=dict(type="str", aliases=["node_profile_name", "logical_node"]),
+        interface_profile=dict(type="str", aliases=["interface_profile_name", "logical_interface"]),
         state=dict(type="str", default="present", choices=["absent", "present", "query"]),
         pod_id=dict(type="str"),
         node_id=dict(type="str"),
@@ -377,8 +373,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ["state", "present", ["interface_type", "pod_id", "node_id", "path_ep"]],
-            ["state", "absent", ["pod_id", "node_id", "path_ep"]],
+            ["state", "present", ["tenant", "l3out", "node_profile", "interface_profile", "interface_type", "pod_id", "node_id", "path_ep"]],
+            ["state", "absent", ["tenant", "l3out", "node_profile", "interface_profile", "pod_id", "node_id", "path_ep"]],
             ["micro_bfd", True, ["micro_bfd_destination"]],
         ],
         required_by={"micro_bfd_timer": "micro_bfd", "micro_bfd_destination": "micro_bfd"},

--- a/tests/integration/targets/aci_l3out_extsubnet/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_extsubnet/tasks/main.yml
@@ -17,7 +17,7 @@
       validate_certs: '{{ aci_validate_certs | default(false) }}'
       use_ssl: '{{ aci_use_ssl | default(true) }}'
       use_proxy: '{{ aci_use_proxy | default(true) }}'
-      output_level: debug
+      output_level: '{{ aci_output_level | default("info") }}'
 
 # CLEAN ENVIRONMENT
 - name: Remove the ansible_tenant
@@ -169,6 +169,8 @@
         - nm_add_another_subnet is changed
         - nm_add_another_subnet.current.0.l3extSubnet.attributes.ip == "192.1.2.0/24"
 
+  # This test was inaccurate but keeping to assure behaviour and added new test for query all
+  # The test does not do a class query but is testing the length of children
   - name: Query all subnets
     cisco.aci.aci_l3out_extsubnet:
       <<: *aci_info
@@ -316,3 +318,15 @@
     ansible.builtin.assert:
       that:
         - nm_aggregate_scope_match is not changed
+
+  - name: Query all external subnets without filters
+    cisco.aci.aci_l3out_extsubnet:
+      <<: *aci_info
+      state: query
+    register: query_all_no_filter
+
+  - name: Verify query all external subnets without filters
+    ansible.builtin.assert:
+      that:
+        - query_all_no_filter is not changed
+        - query_all_no_filter.current | length >= 2

--- a/tests/integration/targets/aci_l3out_floating_svi/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_floating_svi/tasks/main.yml
@@ -181,6 +181,8 @@
     register: query_floating
     when: version.current.0.topSystem.attributes.version is version('5', '>=')
 
+  # This test was inaccurate but keeping to assure behaviour and added new test for query all
+  # The test does not do a class query but is testing the length of children
   - name: Query all floating svis
     cisco.aci.aci_l3out_floating_svi:
       <<: *intf_present
@@ -197,6 +199,20 @@
       - query_floating.current.0.l3extVirtualLIfP.attributes.dn == "uni/tn-ansible_test/out-l3outintftest/lnodep-nodes/lifp-Floating/vlifp-[topology/pod-1/node-201]-[vlan-1]"
       - query_floating.current.0.l3extVirtualLIfP.attributes.encap == "vlan-1"
       - query_all_floating.current.0.l3extLIfP.children | length == 3
+    when: version.current.0.topSystem.attributes.version is version('5', '>=')
+
+  - name: Query all floating svis without filters
+    cisco.aci.aci_l3out_floating_svi:
+      <<: *aci_info
+      state: query
+    register: query_all_no_filter
+    when: version.current.0.topSystem.attributes.version is version('5', '>=')
+
+  - name: Verify query all floating svis without filters
+    ansible.builtin.assert:
+      that:
+      - query_all_no_filter is not changed
+      - query_all_no_filter.current | length >= 2
     when: version.current.0.topSystem.attributes.version is version('5', '>=')
 
   - name: Remove a floating svi

--- a/tests/integration/targets/aci_l3out_floating_svi_path/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_floating_svi_path/tasks/main.yml
@@ -302,6 +302,8 @@
     register: query_floating
     when: version.current.0.topSystem.attributes.version is version('5', '>=')
 
+  # This test was inaccurate but keeping to assure behaviour and added new test for query all
+  # The test does not do a class query but is testing the length of children
   - name: Query all floating svi paths
     cisco.aci.aci_l3out_floating_svi_path:
       <<: *intf_present
@@ -321,6 +323,20 @@
       - query_floating.current.0.l3extRsDynPathAtt.attributes.floatingAddr == "25.45.67.90/24"
       - query_floating.current.0.l3extRsDynPathAtt.attributes.encap == "vlan-2"
       - query_all_floating.current.0.l3extVirtualLIfP.children | length == 2
+    when: version.current.0.topSystem.attributes.version is version('5', '>=')
+
+  - name: Query all floating svi paths without filters
+    cisco.aci.aci_l3out_floating_svi_path:
+      <<: *aci_info
+      state: query
+    register: query_all_no_filter
+    when: version.current.0.topSystem.attributes.version is version('5', '>=')
+
+  - name: Verify query all floating svi paths without filters
+    ansible.builtin.assert:
+      that:
+      - query_all_no_filter is not changed
+      - query_all_no_filter.current | length >= 2
     when: version.current.0.topSystem.attributes.version is version('5', '>=')
 
   - name: Remove a floating svi path

--- a/tests/integration/targets/aci_l3out_floating_svi_path_secondary_ip/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_floating_svi_path_secondary_ip/tasks/main.yml
@@ -11,7 +11,7 @@
       validate_certs: '{{ aci_validate_certs | default(false) }}'
       use_ssl: '{{ aci_use_ssl | default(true) }}'
       use_proxy: '{{ aci_use_proxy | default(true) }}'
-      output_level: '{{ aci_output_level | default("debug") }}'
+      output_level: '{{ aci_output_level | default("info") }}'
 
 # CLEAN ENVIRONMENT
 - name: Remove test tenant before we kickoff
@@ -180,6 +180,8 @@
       state: query
     register: query_ip
 
+  # This test was inaccurate but keeping to assure behaviour and added new test for query all
+  # The test does not do a class query but is testing the length of children
   - name: Query all ips
     cisco.aci.aci_l3out_floating_svi_path_secondary_ip:
       <<: *intf_present
@@ -198,6 +200,18 @@
       - query_all is not changed
       - query_ip.current.0.l3extIp.attributes.addr == "27.45.67.90/24"
       - query_all.current.0.l3extRsDynPathAtt.children | length == 2
+
+  - name: Query all floating svi path secondary ips without filters
+    cisco.aci.aci_l3out_floating_svi_path_secondary_ip:
+      <<: *aci_info
+      state: query
+    register: query_all_no_filter
+
+  - name: Verify query all floating svi path secondary ips without filters
+    ansible.builtin.assert:
+      that:
+      - query_all_no_filter is not changed
+      - query_all_no_filter.current | length >= 2
 
   - name: Delete a floating svi path secondary_ip
     cisco.aci.aci_l3out_floating_svi_path_secondary_ip:

--- a/tests/integration/targets/aci_l3out_floating_svi_secondary_ip/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_floating_svi_secondary_ip/tasks/main.yml
@@ -115,13 +115,27 @@
       - add_another_ip is changed
       - add_ip_nm.current.0.l3extIp.attributes.addr == "25.45.67.90/24"
       - add_another_ip.current.0.l3extIp.attributes.addr == "26.45.67.90/24"
-  
+
+  - name: Query all floating svi secondary ips without filters
+    cisco.aci.aci_l3out_floating_svi_secondary_ip:
+      <<: *aci_info
+      state: query
+    register: query_all_no_filter
+
+  - name: Verify query all floating svi secondary ips without filters
+    ansible.builtin.assert:
+      that:
+      - query_all_no_filter is not changed
+      - query_all_no_filter.current | length >= 2
+
   - name: Query a floating svi secondary_ip
     cisco.aci.aci_l3out_floating_svi_secondary_ip:
       <<: *floating_svi
       state: query
     register: query_ip
 
+  # This test was inaccurate but keeping to assure behaviour and added new test for query all
+  # The test does not do a class query but is testing the length of children
   - name: Query all ips
     cisco.aci.aci_l3out_floating_svi_secondary_ip:
       <<: *intf_present

--- a/tests/integration/targets/aci_l3out_interface/tasks/main.yml
+++ b/tests/integration/targets/aci_l3out_interface/tasks/main.yml
@@ -19,7 +19,7 @@
       validate_certs: '{{ aci_validate_certs | default(false) }}'
       use_ssl: '{{ aci_use_ssl | default(true) }}'
       use_proxy: '{{ aci_use_proxy | default(true) }}'
-      output_level: debug
+      output_level: '{{ aci_output_level | default("info") }}'
 
 # CLEAN ENVIRONMENT
 - name: Remove ansible_tenant if it already exists
@@ -232,6 +232,8 @@
       - query_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.encap == "vlan-913"
       - query_l3out_interface.current.0.l3extRsPathL3OutAtt.attributes.mode == "regular"
 
+  # This test was inaccurate but keeping to assure behaviour and added new test for query all
+  # The test does not do a class query but is testing the length of children
   - name: Query all interfaces
     cisco.aci.aci_l3out_interface:
       <<: *aci_info
@@ -644,15 +646,20 @@
       register: err_micro_bfd_destination_not_provided_micro_bfd
       ignore_errors: true
 
+    - name: Set error message for Verify micro BFD errors
+      ansible.builtin.set_fact:
+        micro_bfd_timer_not_provided_micro_bfd_error: "missing parameter(s) required by 'micro_bfd_timer': micro_bfd"
+        err_micro_bfd_destination_not_provided_micro_bfd_error: "missing parameter(s) required by 'micro_bfd_destination': micro_bfd"
+
     - name: Verify micro BFD errors
       assert:
         that:
         - err_micro_bfd_not_provided_destination is failed
-        - err_micro_bfd_not_provided_destination.msg == "micro_bfd is True but all of the following are missing{{":"}} micro_bfd_destination"
+        - 'err_micro_bfd_not_provided_destination.msg == "micro_bfd is True but all of the following are missing: micro_bfd_destination"'
         - err_micro_bfd_timer_not_provided_micro_bfd is failed
-        - err_micro_bfd_timer_not_provided_micro_bfd.msg == "missing parameter(s) required by 'micro_bfd_timer'{{":"}} micro_bfd"
+        - err_micro_bfd_timer_not_provided_micro_bfd.msg == micro_bfd_timer_not_provided_micro_bfd_error
         - err_micro_bfd_destination_not_provided_micro_bfd is failed
-        - err_micro_bfd_destination_not_provided_micro_bfd.msg == "missing parameter(s) required by 'micro_bfd_destination'{{":"}} micro_bfd"
+        - err_micro_bfd_destination_not_provided_micro_bfd.msg == err_micro_bfd_destination_not_provided_micro_bfd_error
 
     - name: Enable micro BFD on direct port channel interface in the infra SR-MPLS l3out interface (check_mode)
       aci_l3out_interface: &enable_bfd
@@ -739,6 +746,47 @@
     - name: Remove a infra SR-MPLS l3out
       cisco.aci.aci_l3out:
         <<: *aci_infra_sr_mpls_l3out_absent
+
+  # QUERY ALL l3out interfaces without filters
+  - name: Create first l3out interface for query all test
+    cisco.aci.aci_l3out_interface:
+      <<: *aci_info
+      tenant: ansible_tenant
+      l3out: ansible_l3out
+      node_profile: ansible_node_profile
+      interface_profile: ansible_interface_profile
+      pod_id: 1
+      node_id: 201
+      path_ep: eth1/15
+      interface_type: l3-port
+      address: 192.168.50.1/27
+      state: present
+
+  - name: Create second l3out interface for query all test
+    cisco.aci.aci_l3out_interface:
+      <<: *aci_info
+      tenant: ansible_tenant
+      l3out: ansible_l3out
+      node_profile: ansible_node_profile
+      interface_profile: ansible_interface_profile
+      pod_id: 1
+      node_id: 201
+      path_ep: eth1/16
+      interface_type: l3-port
+      address: 192.168.51.1/27
+      state: present
+
+  - name: Query all l3out interfaces without filters
+    cisco.aci.aci_l3out_interface:
+      <<: *aci_info
+      state: query
+    register: query_all_no_filter
+
+  - name: Verify query all l3out interfaces without filters
+    ansible.builtin.assert:
+      that:
+      - query_all_no_filter is not changed
+      - query_all_no_filter.current | length >= 2
 
   # CLEAN UP
   - name: Remove ansible_tenant


### PR DESCRIPTION
fixes #828 