### PR TITLE
[ignore] add pre commit for black (DCNE-724)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 26.3.1
+    hooks:
+      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 159


### PR DESCRIPTION
Added pre-commit with black to enforce black being run on commit. I pushed PR without doing so which resulted in a comment that I think we can prevent doing something like this. 