### PR TITLE
[minor_change] Add support for nameAlias attribute in aci_l4l7_device module (DCNE-716)

### DIFF
--- a/plugins/doc_fragments/name_alias.py
+++ b/plugins/doc_fragments/name_alias.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    # Standard files documentation fragment
+    DOCUMENTATION = r"""
+options:
+  name_alias:
+    description:
+    - The alias for the current object. This relates to the nameAlias field in ACI.
+    type: str
+"""

--- a/plugins/module_utils/aci.py
+++ b/plugins/module_utils/aci.py
@@ -155,6 +155,12 @@ def aci_annotation_spec():
     )
 
 
+def aci_name_alias_spec():
+    return dict(
+        name_alias=dict(type="str"),
+    )
+
+
 def aci_owner_spec():
     return dict(
         owner_key=dict(type="str", no_log=False, fallback=(env_fallback, ["ACI_OWNER_KEY"])),

--- a/plugins/modules/aci_l4l7_device.py
+++ b/plugins/modules/aci_l4l7_device.py
@@ -93,6 +93,7 @@ options:
 extends_documentation_fragment:
 - cisco.aci.aci
 - cisco.aci.annotation
+- cisco.aci.name_alias
 notes:
 - The I(tenant) must exist before using this module in your playbook.
   The M(cisco.aci.aci_tenant) modules can be used for this.
@@ -263,13 +264,14 @@ url:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec
+from ansible_collections.cisco.aci.plugins.module_utils.aci import ACIModule, aci_argument_spec, aci_annotation_spec, aci_name_alias_spec
 from ansible_collections.cisco.aci.plugins.module_utils.constants import L4L7_FUNC_TYPES_MAPPING
 
 
 def main():
     argument_spec = aci_argument_spec()
     argument_spec.update(aci_annotation_spec())
+    argument_spec.update(aci_name_alias_spec())
     argument_spec.update(
         tenant=dict(type="str", aliases=["tenant_name"]),
         name=dict(type="str", aliases=["device", "device_name", "logical_device", "logical_device_name"]),
@@ -308,6 +310,7 @@ def main():
     trunking = aci.boolean(module.params.get("trunking"))
     domain = module.params.get("domain")
     active_active_mode = aci.boolean(module.params.get("active_active_mode"))
+    name_alias = module.params.get("name_alias")
 
     aci.construct_url(
         root_class=dict(
@@ -349,6 +352,7 @@ def main():
                 svcType=service_type.upper(),
                 trunking=trunking,
                 activeActive=active_active_mode,
+                nameAlias=name_alias,
             ),
             child_configs=child_configs,
         )

--- a/tests/integration/targets/aci_l4l7_device/tasks/main.yml
+++ b/tests/integration/targets/aci_l4l7_device/tasks/main.yml
@@ -80,6 +80,7 @@
     svc_type: adc
     trunking: false
     prom_mode: true
+    name_alias: ansible_device_alias
     state: present
   check_mode: true
   register: create_l4l7_device_cm
@@ -132,6 +133,7 @@
     - create_l4l7_device_cm.proposed.vnsLDevVip.attributes.promMode == "yes"
     - create_l4l7_device_cm.proposed.vnsLDevVip.attributes.svcType == "ADC"
     - create_l4l7_device_cm.proposed.vnsLDevVip.attributes.trunking == "no"
+    - create_l4l7_device_cm.proposed.vnsLDevVip.attributes.nameAlias == "ansible_device_alias"
     - create_l4l7_device.current.0.vnsLDevVip.attributes.dn == "uni/tn-ansible_tenant/lDevVip-ansible_device"
     - create_l4l7_device.current.0.vnsLDevVip.attributes.name == "ansible_device"
     - create_l4l7_device.current.0.vnsLDevVip.attributes.contextAware == "single-Context"
@@ -142,6 +144,7 @@
     - create_l4l7_device.current.0.vnsLDevVip.attributes.promMode == "yes"
     - create_l4l7_device.current.0.vnsLDevVip.attributes.svcType == "ADC"
     - create_l4l7_device.current.0.vnsLDevVip.attributes.trunking == "no"
+    - create_l4l7_device.current.0.vnsLDevVip.attributes.nameAlias == "ansible_device_alias"
     - create_virt_l4l7_device.current.0.vnsLDevVip.attributes.dn == "uni/tn-ansible_tenant/lDevVip-ansible_virt_device"
     - create_virt_l4l7_device.current.0.vnsLDevVip.attributes.name == "ansible_virt_device"
     - create_virt_l4l7_device.current.0.vnsLDevVip.attributes.contextAware == "single-Context"
@@ -183,6 +186,7 @@
     svc_type: fw
     trunking: true
     prom_mode: false
+    name_alias: ansible_device_alias_updated
     state: present
   register: update_l4l7_device
 
@@ -200,6 +204,7 @@
     - update_l4l7_device.current.0.vnsLDevVip.attributes.promMode == "no"
     - update_l4l7_device.current.0.vnsLDevVip.attributes.svcType == "FW"
     - update_l4l7_device.current.0.vnsLDevVip.attributes.trunking == "yes"
+    - update_l4l7_device.current.0.vnsLDevVip.attributes.nameAlias == "ansible_device_alias_updated"
 
 - name: Verify domain binding object
   ansible.builtin.assert:
@@ -253,6 +258,7 @@
     - query_l4l7_device.current.0.vnsLDevVip.attributes.promMode == "no"
     - query_l4l7_device.current.0.vnsLDevVip.attributes.svcType == "FW"
     - query_l4l7_device.current.0.vnsLDevVip.attributes.trunking == "yes"
+    - query_l4l7_device.current.0.vnsLDevVip.attributes.nameAlias == "ansible_device_alias_updated"
 
 - name: Query all L4-L7 Devices
   cisco.aci.aci_l4l7_device:


### PR DESCRIPTION
fixes #831

created a doc_fragment and spec since nameAlias is an attribute that is available on a lot of classes, this allows us to quicker add it consistently next time a nameAlias attribute is missing from module