### PR TITLE
[bugfix] Remove the need of required path attributes on create and up date to allow for vnic configuration without path in aci_l4l7_concrete_interface module (DCNE-715)

### DIFF
--- a/plugins/modules/aci_access_span_src_group.py
+++ b/plugins/modules/aci_access_span_src_group.py
@@ -293,7 +293,7 @@ def main():
                     #         }
                     #     }
                     # )
-                    aci.api_call("DELETE", "/api/mo/uni/infra/srcgrp-{0}/rssrcGrpToFilterGrp.json".format(source_group))
+                    aci.api_call("DELETE", "{0}/api/mo/uni/infra/srcgrp-{1}/rssrcGrpToFilterGrp.json".format(aci.base_url, source_group))
                 elif child.get("spanSpanLbl") and child.get("spanSpanLbl").get("attributes").get("name") != destination_group:
                     child_configs.append(
                         {

--- a/plugins/modules/aci_access_span_src_group_src.py
+++ b/plugins/modules/aci_access_span_src_group_src.py
@@ -408,13 +408,13 @@ def main():
                     #         }
                     #     }
                     # )
-                    aci.api_call("DELETE", "{0}/rssrcToFilterGrp.json".format(source_path))
+                    aci.api_call("DELETE", "{0}/{1}/rssrcToFilterGrp.json".format(aci.base_url, source_path))
                 elif child.get("spanRsSrcToEpg") and child.get("spanRsSrcToEpg").get("attributes").get("tDn") != epg_dn:
                     # Appending to child_config list not possible because of APIC Error 103: child (Rn) of class spanRsSrcToEpg is already attached.
-                    aci.api_call("DELETE", "{0}/rssrcToEpg.json".format(source_path))
+                    aci.api_call("DELETE", "{0}/{1}/rssrcToEpg.json".format(aci.base_url, source_path))
                 elif child.get("spanRsSrcToL3extOut") and child.get("spanRsSrcToL3extOut").get("attributes").get("tDn") != l3ext_out_dn:
                     # Appending to child_config list not possible because of APIC Error 103: child (Rn) of class spanRsSrcToL3extOut is already attached.
-                    aci.api_call("DELETE", "{0}/rssrcToL3extOut.json".format(source_path))
+                    aci.api_call("DELETE", "{0}/{1}/rssrcToL3extOut.json".format(aci.base_url, source_path))
 
         aci.payload(
             aci_class="spanSrc",

--- a/plugins/modules/aci_fabric_span_src_group_src.py
+++ b/plugins/modules/aci_fabric_span_src_group_src.py
@@ -385,10 +385,10 @@ def main():
             for child in aci.existing[0].get("spanSrc", {}).get("children", {}):
                 if child.get("spanRsSrcToCtx") and child.get("spanRsSrcToCtx").get("attributes").get("tDn") != vrf_dn:
                     # Appending to child_config list not possible because of APIC Error 103: child (Rn) of class spanRsSrcToCtx is already attached.
-                    aci.api_call("DELETE", "{0}/rssrcToCtx.json".format(source_path))
+                    aci.api_call("DELETE", "{0}/{1}/rssrcToCtx.json".format(aci.base_url, source_path))
                 elif child.get("spanRsSrcToBD") and child.get("spanRsSrcToBD").get("attributes").get("tDn") != bd_dn:
                     # Appending to child_config list not possible because of APIC Error 103: child (Rn) of class spanRsSrcToBD is already attached.
-                    aci.api_call("DELETE", "{0}/rssrcToBD.json".format(source_path))
+                    aci.api_call("DELETE", "{0}/{1}/rssrcToBD.json".format(aci.base_url, source_path))
 
         aci.payload(
             aci_class="spanSrc",

--- a/plugins/modules/aci_l4l7_concrete_interface.py
+++ b/plugins/modules/aci_l4l7_concrete_interface.py
@@ -384,7 +384,8 @@ def main():
                 # A separate delete request is needed to remove the existing path binding prior to adding the new one.
                 aci.api_call(
                     "DELETE",
-                    "/api/mo/uni/tn-{0}/lDevVip-{1}/cDev-{2}/cIf-[{3}]/rsCIfPathAtt.json".format(
+                    "{0}/api/mo/uni/tn-{1}/lDevVip-{2}/cDev-{3}/cIf-[{4}]/rsCIfPathAtt.json".format(
+                        aci.base_url,
                         tenant,
                         logical_device,
                         concrete_device,

--- a/plugins/modules/aci_l4l7_concrete_interface.py
+++ b/plugins/modules/aci_l4l7_concrete_interface.py
@@ -42,18 +42,23 @@ options:
   pod_id:
     description:
       - The unique identifier for the pod where the concrete interface is located.
+      - Required when I(interface) is provided.
     type: int
   node_id:
     description:
       - The unique identifier for the node where the concrete interface is located.
       - For Ports and Port-channels, this is represented as a single node ID.
       - For virtual Port Channels (vPCs), this is represented as a hyphen-separated pair of node IDs, such as "201-202".
+      - Required when I(interface) is provided.
     type: str
   interface:
     description:
     - The path to the physical interface.
     - For single ports, this is the port name, e.g. "eth1/15".
     - For Port-channels and vPCs, this is the Interface Policy Group name.
+    - When provided with a non-empty value, I(pod_id) and I(node_id) are required.
+    - When set to an empty string, the existing path binding will be removed.
+    - When not provided, the existing path binding will not be modified.
     type: str
     aliases: [ path_ep, interface_name, interface_policy_group, interface_policy_group_name ]
   vnic_name:
@@ -139,6 +144,32 @@ EXAMPLES = r"""
     state: query
   delegate_to: localhost
   register: query_result
+
+- name: Add a new concrete interface without a path binding
+  cisco.aci.aci_l4l7_concrete_interface:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    device: my_device
+    concrete_device: my_concrete_device
+    name: my_concrete_interface
+    vnic_name: my_vnic
+    state: present
+  delegate_to: localhost
+
+- name: Remove the path binding from an existing concrete interface
+  cisco.aci.aci_l4l7_concrete_interface:
+    host: apic
+    username: admin
+    password: SomeSecretPassword
+    tenant: my_tenant
+    device: my_device
+    concrete_device: my_concrete_device
+    name: my_concrete_interface
+    interface: ""
+    state: present
+  delegate_to: localhost
 
 - name: Delete a concrete interface
   cisco.aci.aci_l4l7_concrete_interface:
@@ -283,7 +314,7 @@ def main():
         supports_check_mode=True,
         required_if=[
             ["state", "absent", ["tenant", "logical_device", "concrete_device", "name"]],
-            ["state", "present", ["tenant", "logical_device", "concrete_device", "name", "pod_id", "node_id", "interface"]],
+            ["state", "present", ["tenant", "logical_device", "concrete_device", "name"]],
         ],
     )
 
@@ -296,6 +327,11 @@ def main():
     node_id = module.params.get("node_id")
     interface = module.params.get("interface")
     vnic_name = module.params.get("vnic_name")
+
+    # required_by and required_together cannot be used here because interface="" (empty string)
+    # is a valid input to remove the path binding, and should not require pod_id and node_id.
+    if interface and (pod_id is None or node_id is None):
+        module.fail_json(msg="pod_id and node_id are required when interface is provided.")
 
     aci = ACIModule(module)
 
@@ -330,20 +366,49 @@ def main():
     aci.get_existing()
 
     if state == "present":
-        path_dn = "topology/pod-{0}/{1}-{2}/pathep-[{3}]".format(pod_id, "protpaths" if "-" in node_id else "paths", node_id, interface)
+        child_configs = []
+        if interface:
+            path_dn = "topology/pod-{0}/{1}-{2}/pathep-[{3}]".format(pod_id, "protpaths" if "-" in node_id else "paths", node_id, interface)
+            # When updating the path binding, the existing path must be removed first in a separate request
+            # because APIC does not allow two children of the same class (vnsRsCIfPathAtt) in a single payload.
+            existing_path = (
+                aci.existing[0].get("vnsCIf", {}).get("children", [{}])[0].get("vnsRsCIfPathAtt", {}).get("attributes", {}).get("tDn")
+                if aci.existing
+                else None
+            )
+            if existing_path and existing_path != path_dn:
+                # Appending to child_config list not possible because of following errors:
+                #   APIC Error 103: child (Rn) of class vnsRsCIfPathAtt is already attached.
+                #   APIC Error 100: Validation failed: Statically deploying LDevVip on same node on different Pods:
+                #     topology/pod-2/paths-201/pathep-[eth1/16] and topology/pod-1/paths-201/pathep-[eth1/16]
+                # A separate delete request is needed to remove the existing path binding prior to adding the new one.
+                aci.api_call(
+                    "DELETE",
+                    "/api/mo/uni/tn-{0}/lDevVip-{1}/cDev-{2}/cIf-[{3}]/rsCIfPathAtt.json".format(
+                        tenant,
+                        logical_device,
+                        concrete_device,
+                        name,
+                    ),
+                )
+            child_configs.append(
+                dict(vnsRsCIfPathAtt=dict(attributes=dict(tDn=path_dn))),
+            )
+        elif interface == "":
+            # Only send the delete child config when an existing path binding is present
+            # This is done to preserve idempotency
+            if aci.existing and aci.existing[0].get("vnsCIf", {}).get("children"):
+                child_configs.append(
+                    dict(vnsRsCIfPathAtt=dict(attributes=dict(status="deleted"))),
+                )
+
         aci.payload(
             aci_class="vnsCIf",
             class_config=dict(
                 name=name,
                 vnicName=vnic_name,
             ),
-            child_configs=[
-                dict(
-                    vnsRsCIfPathAtt=dict(
-                        attributes=dict(tDn=path_dn),
-                    ),
-                ),
-            ],
+            child_configs=child_configs,
         )
         aci.get_diff(aci_class="vnsCIf")
 

--- a/tests/integration/targets/aci_l4l7_concrete_interface/tasks/main.yml
+++ b/tests/integration/targets/aci_l4l7_concrete_interface/tasks/main.yml
@@ -202,6 +202,111 @@
     - delete_concrete_interface_cm.proposed == {}
     - delete_concrete_interface_cm.previous == delete_concrete_interface.previous == add_concrete_interface_update.current
 
+# ADD L4-L7 CONCRETE INTERFACE WITHOUT PATH BINDING
+- name: Create L4-L7 Concrete Interface without path in check mode
+  cisco.aci.aci_l4l7_concrete_interface: &l4l7_concrete_interface_no_path
+    <<: *aci_info
+    tenant: ansible_tenant
+    device: ansible_device
+    concrete_device: ansible_concrete_device
+    concrete_interface: ansible_concrete_interface_no_path
+    vnic_name: my_vnic
+    state: present
+  check_mode: true
+  register: add_no_path_cm
+
+- name: Create L4-L7 Concrete Interface without path
+  cisco.aci.aci_l4l7_concrete_interface:
+    <<: *l4l7_concrete_interface_no_path
+  register: add_no_path
+
+- name: Create L4-L7 Concrete Interface without path again
+  cisco.aci.aci_l4l7_concrete_interface:
+    <<: *l4l7_concrete_interface_no_path
+  register: add_no_path_again
+
+- name: Verify L4-L7 Concrete Interface without path
+  ansible.builtin.assert:
+    that:
+    - add_no_path_cm is changed
+    - add_no_path is changed
+    - add_no_path_again is not changed
+    - add_no_path_cm.proposed.vnsCIf.attributes.dn == "uni/tn-ansible_tenant/lDevVip-ansible_device/cDev-ansible_concrete_device/cIf-[ansible_concrete_interface_no_path]"
+    - add_no_path_cm.proposed.vnsCIf.attributes.name == "ansible_concrete_interface_no_path"
+    - add_no_path_cm.proposed.vnsCIf.attributes.vnicName == "my_vnic"
+    - add_no_path.current.0.vnsCIf.attributes.dn == "uni/tn-ansible_tenant/lDevVip-ansible_device/cDev-ansible_concrete_device/cIf-[ansible_concrete_interface_no_path]"
+    - add_no_path.current.0.vnsCIf.attributes.name == "ansible_concrete_interface_no_path"
+    - add_no_path.current.0.vnsCIf.attributes.vnicName == "my_vnic"
+    - add_no_path.current.0.vnsCIf.children is not defined
+    - add_no_path.previous == []
+    - add_no_path_again.previous == add_no_path_again.current == add_no_path.current
+
+# UPDATE L4-L7 CONCRETE INTERFACE WITHOUT PATH - ADD PATH BINDING
+- name: Add path binding to existing concrete interface without path
+  cisco.aci.aci_l4l7_concrete_interface:
+    <<: *l4l7_concrete_interface_no_path
+    pod_id: 1
+    node_id: "201"
+    interface: eth1/16
+  register: add_path_to_no_path
+
+- name: Verify path binding was added
+  ansible.builtin.assert:
+    that:
+    - add_path_to_no_path is changed
+    - add_path_to_no_path.current.0.vnsCIf.children.0.vnsRsCIfPathAtt.attributes.tDn == "topology/pod-1/paths-201/pathep-[eth1/16]"
+
+# REMOVE PATH BINDING FROM CONCRETE INTERFACE
+- name: Remove path binding in check mode
+  cisco.aci.aci_l4l7_concrete_interface: &remove_path_binding
+    <<: *aci_info
+    tenant: ansible_tenant
+    device: ansible_device
+    concrete_device: ansible_concrete_device
+    concrete_interface: ansible_concrete_interface_no_path
+    interface: ""
+    state: present
+  check_mode: true
+  register: remove_path_cm
+
+- name: Remove path binding
+  cisco.aci.aci_l4l7_concrete_interface:
+    <<: *remove_path_binding
+  register: remove_path
+
+- name: Remove path binding again
+  cisco.aci.aci_l4l7_concrete_interface:
+    <<: *remove_path_binding
+  register: remove_path_again
+
+- name: Verify path binding removal
+  ansible.builtin.assert:
+    that:
+    - remove_path_cm is changed
+    - remove_path is changed
+    - remove_path_again is not changed
+    - remove_path.current.0.vnsCIf.attributes.name == "ansible_concrete_interface_no_path"
+    - remove_path.current.0.vnsCIf.children is not defined
+
+# ERROR VALIDATION - INTERFACE WITHOUT POD_ID AND NODE_ID
+- name: Create L4-L7 Concrete Interface with interface but without pod_id and node_id
+  cisco.aci.aci_l4l7_concrete_interface:
+    <<: *aci_info
+    tenant: ansible_tenant
+    device: ansible_device
+    concrete_device: ansible_concrete_device
+    concrete_interface: ansible_concrete_interface_error
+    interface: eth1/16
+    state: present
+  register: error_missing_pod_node
+  ignore_errors: true
+
+- name: Verify error message for missing pod_id and node_id
+  ansible.builtin.assert:
+    that:
+    - error_missing_pod_node is failed
+    - error_missing_pod_node.msg == "pod_id and node_id are required when interface is provided."
+
 # CLEAN UP
 - name: Remove ansible_tenant
   cisco.aci.aci_tenant:


### PR DESCRIPTION
fixes #830 