### PR TITLE
Fix incorrect module name in aci_match_route_destination examples

### DIFF
--- a/plugins/modules/aci_match_route_destination.py
+++ b/plugins/modules/aci_match_route_destination.py
@@ -83,8 +83,8 @@ author:
 """
 
 EXAMPLES = r"""
-- name: Create a match rule destination
-  cisco.aci.aci_match_rule_destination:
+- name: Create a match route destination
+  cisco.aci.aci_match_route_destination:
     host: apic
     username: admin
     password: SomeSecretPassword
@@ -97,8 +97,8 @@ EXAMPLES = r"""
     state: present
   delegate_to: localhost
 
-- name: Query all match rules destination
-  cisco.aci.aci_match_rule_destination:
+- name: Query all match routes destination
+  cisco.aci.aci_match_route_destination:
     host: apic
     username: admin
     password: SomeSecretPassword
@@ -106,8 +106,8 @@ EXAMPLES = r"""
   delegate_to: localhost
   register: query_result
 
-- name: Query a specific match rule destination
-  cisco.aci.aci_match_rule_destination:
+- name: Query a specific match route destination
+  cisco.aci.aci_match_route_destination:
     host: apic
     username: admin
     password: SomeSecretPassword
@@ -118,8 +118,8 @@ EXAMPLES = r"""
   delegate_to: localhost
   register: query_result
 
-- name: Delete a match rule destination
-  cisco.aci.aci_match_rule_destination:
+- name: Delete a match route destination
+  cisco.aci.aci_match_route_destination:
     host: apic
     username: admin
     password: SomeSecretPassword


### PR DESCRIPTION
## Summary

The documentation example references the wrong module name.

Current:

cisco.aci.aci_match_rule_destination

Expected:

cisco.aci.aci_match_route_destination

This appears to be a copy/paste typo.